### PR TITLE
Add --json flag to output JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Creates a release or adds issues to the current release. This is the default com
 linear-release sync
 
 # Specify custom name and version
-linear-release sync --name="v1.2.0" --version="1.2.0"
+linear-release sync --name="Release 1.2.0" --version="1.2.0"
 ```
 
 ### `complete`
@@ -131,6 +131,18 @@ linear-release update --stage="in review" --version="1.2.0"
 | `--version`       | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, if omitted, targets the most recent started release. |
 | `--stage`         | `update`                     | Target deployment stage (required for `update`)                                                                                                          |
 | `--include-paths` | `sync`                       | Filter commits by changed file paths                                                                                                                     |
+| `--json`          | `sync`, `complete`, `update` | Output result as JSON                                                                                                                                    |
+
+### JSON Output
+
+Use `--json` to get structured output for scripting.
+
+```bash
+linear-release sync --json
+# => {"release":{"id":"...","name":"Release 1.2.0","version":"1.2.0","url":"https://linear.app/..."}}
+```
+
+When no release is created (e.g. no commits found), `--json` outputs `{"release":null}`.
 
 ### Path Filtering
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,5 +1,15 @@
+let useStderr = false;
+
+export function setStderr(value: boolean) {
+  useStderr = value;
+}
+
 export function log(message: string) {
   if (process.env.NODE_ENV !== "test") {
-    console.log(`=> ${message}`);
+    if (useStderr) {
+      process.stderr.write(`=> ${message}\n`);
+    } else {
+      console.log(`=> ${message}`);
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,10 @@ export type AccessKeyCompleteReleaseResponse = {
     releaseCompleteByAccessKey: {
       success: boolean;
       release: {
+        id: string;
         name: string;
+        version?: string;
+        url?: string;
       } | null;
     };
   };
@@ -48,7 +51,10 @@ export type AccessKeyUpdateByPipelineResponse = {
     releaseUpdateByPipelineByAccessKey: {
       success: boolean;
       release: {
+        id: string;
         name: string;
+        version?: string;
+        url?: string;
         stage: {
           name: string;
         } | null;


### PR DESCRIPTION
  - Add `--json` flag that outputs structured JSON to stdout and redirects logs to stderr
  - Add `url`, `name`, and `version` to all GraphQL mutation responses (sync, complete, update)
  - Output `{"release":null}` when no release is created

Mostly for https://github.com/linear/linear-release-action/pull/2