### PR TITLE
Fix --version being used twice + use parseArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ linear-release update --stage="in review" --release-version="1.2.0"
 
 ### CLI Options
 
-| Option            | Commands                     | Description                                                                                                                                              |
-| ----------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`          | `sync`                       | Custom release name. Defaults to short commit hash.                                                                                                      |
+| Option              | Commands                     | Description                                                                                                                                              |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name`            | `sync`                       | Custom release name. Defaults to short commit hash.                                                                                                      |
 | `--release-version` | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, if omitted, targets the most recent started release. |
-| `--stage`         | `update`                     | Target deployment stage (required for `update`)                                                                                                          |
-| `--include-paths` | `sync`                       | Filter commits by changed file paths                                                                                                                     |
-| `--json`          | `sync`, `complete`, `update` | Output result as JSON                                                                                                                                    |
+| `--stage`           | `update`                     | Target deployment stage (required for `update`)                                                                                                          |
+| `--include-paths`   | `sync`                       | Filter commits by changed file paths                                                                                                                     |
+| `--json`            | `sync`, `complete`, `update` | Output result as JSON                                                                                                                                    |
 
 ### JSON Output
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Creates a release or adds issues to the current release. This is the default com
 linear-release sync
 
 # Specify custom name and version
-linear-release sync --name="Release 1.2.0" --version="1.2.0"
+linear-release sync --name="Release 1.2.0" --release-version="1.2.0"
 ```
 
 ### `complete`
@@ -100,7 +100,7 @@ Marks a release as complete. Only applicable to scheduled pipelines, as continuo
 linear-release complete
 
 # Completes the release with the specified version
-linear-release complete --version="1.2.0"
+linear-release complete --release-version="1.2.0"
 ```
 
 ### `update`
@@ -112,7 +112,7 @@ Updates a release's deployment stage. Only applicable to scheduled pipelines, as
 linear-release update --stage="in review"
 
 # Updates the release with the specified version
-linear-release update --stage="in review" --version="1.2.0"
+linear-release update --stage="in review" --release-version="1.2.0"
 ```
 
 ## Configuration
@@ -128,7 +128,7 @@ linear-release update --stage="in review" --version="1.2.0"
 | Option            | Commands                     | Description                                                                                                                                              |
 | ----------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--name`          | `sync`                       | Custom release name. Defaults to short commit hash.                                                                                                      |
-| `--version`       | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, if omitted, targets the most recent started release. |
+| `--release-version` | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, if omitted, targets the most recent started release. |
 | `--stage`         | `update`                     | Target deployment stage (required for `update`)                                                                                                          |
 | `--include-paths` | `sync`                       | Filter commits by changed file paths                                                                                                                     |
 | `--json`          | `sync`, `complete`, `update` | Output result as JSON                                                                                                                                    |

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { parseCLIArgs } from "./args";
+
+describe("parseCLIArgs", () => {
+  it("defaults command to sync when no positional given", () => {
+    const result = parseCLIArgs([]);
+    expect(result.command).toBe("sync");
+  });
+
+  it("parses explicit sync command", () => {
+    const result = parseCLIArgs(["sync"]);
+    expect(result.command).toBe("sync");
+  });
+
+  it("parses explicit complete command", () => {
+    const result = parseCLIArgs(["complete"]);
+    expect(result.command).toBe("complete");
+  });
+
+  it("parses explicit update command", () => {
+    const result = parseCLIArgs(["update"]);
+    expect(result.command).toBe("update");
+  });
+
+  it("parses --release-version", () => {
+    const result = parseCLIArgs(["--release-version", "1.2.0"]);
+    expect(result.releaseVersion).toBe("1.2.0");
+  });
+
+  it("parses --release-version with = syntax", () => {
+    const result = parseCLIArgs(["--release-version=1.2.0"]);
+    expect(result.releaseVersion).toBe("1.2.0");
+  });
+
+  it("parses --name", () => {
+    const result = parseCLIArgs(["--name", "Release 1.2.0"]);
+    expect(result.releaseName).toBe("Release 1.2.0");
+  });
+
+  it("parses --stage", () => {
+    const result = parseCLIArgs(["--stage", "production"]);
+    expect(result.stageName).toBe("production");
+  });
+
+  it("defaults --json to false", () => {
+    const result = parseCLIArgs([]);
+    expect(result.jsonOutput).toBe(false);
+  });
+
+  it("parses --json to true when passed", () => {
+    const result = parseCLIArgs(["--json"]);
+    expect(result.jsonOutput).toBe(true);
+  });
+
+  it("splits --include-paths by comma and trims whitespace", () => {
+    const result = parseCLIArgs(["--include-paths", "apps/web/** , packages/** , libs/core/**"]);
+    expect(result.includePaths).toEqual(["apps/web/**", "packages/**", "libs/core/**"]);
+  });
+
+  it("returns empty array for --include-paths with empty string", () => {
+    const result = parseCLIArgs(["--include-paths", ""]);
+    expect(result.includePaths).toEqual([]);
+  });
+
+  it("returns empty array when --include-paths is not provided", () => {
+    const result = parseCLIArgs([]);
+    expect(result.includePaths).toEqual([]);
+  });
+
+  it("parses command combined with multiple options", () => {
+    const result = parseCLIArgs(["update", "--stage=production", "--release-version", "1.2.0", "--json"]);
+    expect(result.command).toBe("update");
+    expect(result.stageName).toBe("production");
+    expect(result.releaseVersion).toBe("1.2.0");
+    expect(result.jsonOutput).toBe(true);
+  });
+
+  it("strips empty entries from --include-paths with trailing/leading commas", () => {
+    const result = parseCLIArgs(["--include-paths", ",apps/web/**,packages/**,"]);
+    expect(result.includePaths).toEqual(["apps/web/**", "packages/**"]);
+  });
+
+  it("throws on unknown flags (strict mode)", () => {
+    expect(() => parseCLIArgs(["--unknown-flag"])).toThrow();
+  });
+});

--- a/src/args.ts
+++ b/src/args.ts
@@ -1,0 +1,30 @@
+import { parseArgs } from "node:util";
+
+export function parseCLIArgs(argv: string[]) {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      name: { type: "string" },
+      "release-version": { type: "string" },
+      stage: { type: "string" },
+      "include-paths": { type: "string" },
+      json: { type: "boolean", default: false },
+    },
+    allowPositionals: true,
+    strict: true,
+  });
+
+  return {
+    command: positionals[0] || "sync",
+    releaseName: values.name,
+    releaseVersion: values["release-version"],
+    stageName: values.stage,
+    includePaths: values["include-paths"]
+      ? values["include-paths"]
+          .split(",")
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0)
+      : [],
+    jsonOutput: values.json ?? false,
+  };
+}


### PR DESCRIPTION
  - Rename `--version` flag to `--release-version` to avoid conflict with `-v`/`--version` (show version)
  - Extract `parseCLIArgs` into src/args.ts with test coverage
  - Wrap arg parsing in try/catch for clean error messages on invalid flags

Fixes LIN-58727
Fixes LIN-58887