### PR TITLE
Align issue ID matching with Linear matching logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-release",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "CLI tool to integrate CI/CD pipelines with Linear releases",
   "homepage": "https://github.com/linear/linear-release",


### PR DESCRIPTION
- Commit messages now require a magic word (Fixes, Closes, Part of, etc.) before issue identifiers are extracted — branch names still extract all matches unconditionally
- Linear issue URLs are normalized to raw identifiers before magic word matching, so `Fixes https://linear.app/myorg/issue/LIN-123/fix-auth` works the same as `Fixes LIN-123`
- Prevents issues from being incorrectly marked as released when they're merely mentioned in a commit message without a closing/contributing keyword