### PR TITLE
Properly ignore revert branches pattern

### DIFF
--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -384,6 +384,35 @@ describe("commit message magic word behavior", () => {
   });
 });
 
+describe("revert branch handling", () => {
+  it("blocks extraction from merge commit with revert branch name", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: "revert-571-romain/bac-39",
+      message: "Merge pull request #572 from org/revert-571-romain/bac-39",
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("blocks extraction when revert branch has multiple identifiers", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: "revert-571-romain/drive-320-and-drive-321",
+      message: null,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("blocks PR number extraction from revert branch", () => {
+    const result = extractPullRequestNumbersForCommit({
+      sha: "abc",
+      branchName: "revert-571-romain/bac-39",
+      message: "Merge pull request #572 from org/revert-571-romain/bac-39",
+    });
+    expect(result).toEqual([]);
+  });
+});
+
 describe("extractPullRequestNumbersForCommit", () => {
   // Messages that should extract PR numbers
   it.each([

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -134,6 +134,12 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): s
     return [];
   }
 
+  // GitHub auto-generates branch names like "revert-571-romain/bac-39" for revert PRs.
+  // Block extraction to prevent the original issue identifier from being added to the release.
+  if (/(^|\/)revert-\d+-/i.test(commit.branchName ?? "")) {
+    return [];
+  }
+
   const found = new Map<string, string>();
 
   // Branch name: extract all matches (branch names are always intentional)
@@ -169,6 +175,12 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
   // Skip reverts - they reference the original PR, not a new one
   if (/^Revert "/i.test(message)) {
     log(`Skipping revert commit ${commit.sha} with message: "${message}"`);
+    return [];
+  }
+
+  // Skip merge commits of revert PRs — branch name like "revert-571-romain/bac-39"
+  if (/(^|\/)revert-\d+-/i.test(commit.branchName ?? "")) {
+    log(`Skipping revert merge commit ${commit.sha}`);
     return [];
   }
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -137,6 +137,7 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): s
   // GitHub auto-generates branch names like "revert-571-romain/bac-39" for revert PRs.
   // Block extraction to prevent the original issue identifier from being added to the release.
   if (/(^|\/)revert-\d+-/i.test(commit.branchName ?? "")) {
+    log(`Skipping revert branch ${commit.branchName} for commit ${commit.sha}`);
     return [];
   }
 


### PR DESCRIPTION
When a PR is reverted on GitHub, the merge commit of the revert has an auto-generated branch name like `revert-571-romain/bac-39`. The branch extractor picks up BAC-39 and adds it to the release, the opposite of what should happen.

On Gitlab, branch is named `revert-<sha>` so not a problem.

---

This is step 1 of a larger plan to handle reverts in a better way. Next step is actually identifying reverts and removing issues from the release (for in-progress scheduled). Continuous TBD what we want.