### PR TITLE
Better revert detection

### DIFF
--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -442,6 +442,7 @@ describe("getRevertBranchDepth", () => {
     ["revert-571-romain/bac-39", 1],
     ["revert-572-revert-571-romain/bac-39", 2],
     ["revert-574-revert-573-revert-572-romain/bac-39", 3],
+    ["org/revert-572-revert-571-romain/bac-39", 2],
   ])("branch %j → depth %d", (branch, expected) => {
     expect(getRevertBranchDepth(branch)).toBe(expected);
   });

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { extractLinearIssueIdentifiersForCommit, extractPullRequestNumbersForCommit } from "./extractors";
+import {
+  extractLinearIssueIdentifiersForCommit,
+  extractPullRequestNumbersForCommit,
+  getRevertBranchDepth,
+  getRevertMessageDepth,
+} from "./extractors";
 import { CommitContext } from "./types";
 
 describe("extractLinearIssueIdentifiersForCommit", () => {
@@ -88,7 +93,7 @@ describe("extractLinearIssueIdentifiersForCommit", () => {
   });
 });
 
-describe("version suffix handling ", () => {
+describe("version suffix handling", () => {
   // Version strings should NOT match
   it.each([
     ["release/ios-1.57.1", []],
@@ -124,7 +129,7 @@ describe("version suffix handling ", () => {
   });
 });
 
-describe("leading zero rejection ", () => {
+describe("leading zero rejection", () => {
   it("rejects LIN-0004 style identifiers", () => {
     const result = extractLinearIssueIdentifiersForCommit({
       sha: "abc",
@@ -135,8 +140,7 @@ describe("leading zero rejection ", () => {
   });
 });
 
-describe("underscore handling ", () => {
-  // Underscores act as word boundaries
+describe("underscore handling", () => {
   it.each([
     ["story/LIN-123_LIN-321_hello_world", ["LIN-123", "LIN-321"]],
     ["username/lin-123_branch_name", ["LIN-123"]],
@@ -150,7 +154,7 @@ describe("underscore handling ", () => {
   });
 });
 
-describe("multiple identifiers ", () => {
+describe("multiple identifiers", () => {
   it.each([
     ["Fixes LIN-123 and LIN-321", ["LIN-123", "LIN-321"]],
     ["Closes LIN-123, LIN-321", ["LIN-123", "LIN-321"]],
@@ -410,6 +414,49 @@ describe("revert branch handling", () => {
       message: "Merge pull request #572 from org/revert-571-romain/bac-39",
     });
     expect(result).toEqual([]);
+  });
+
+  it("blocks add-extraction from message-only revert with magic word", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: 'Revert "Fixes ENG-100"',
+    });
+    expect(result).toEqual([]);
+  });
+
+  it("allows extraction from revert-of-revert branch (even depth)", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: "revert-572-revert-571-romain/bac-39",
+      message: null,
+    });
+    expect(result).toEqual(["BAC-39"]);
+  });
+});
+
+describe("getRevertBranchDepth", () => {
+  it.each([
+    [null, 0],
+    ["romain/bac-39", 0],
+    ["revert-571-romain/bac-39", 1],
+    ["revert-572-revert-571-romain/bac-39", 2],
+    ["revert-574-revert-573-revert-572-romain/bac-39", 3],
+  ])("branch %j → depth %d", (branch, expected) => {
+    expect(getRevertBranchDepth(branch)).toBe(expected);
+  });
+});
+
+describe("getRevertMessageDepth", () => {
+  it.each([
+    [null, 0],
+    ["Fix memory leak", 0],
+    ['Revert "DRIVE-320: Fix"', 1],
+    ['Revert "Revert "DRIVE-320: Fix""', 2],
+    ['Revert "Revert "Revert "DRIVE-320: Fix"""', 3],
+    ['Reapply "DRIVE-320: Fix"', 0],
+  ])("message %j → depth %d", (message, expected) => {
+    expect(getRevertMessageDepth(message)).toBe(expected);
   });
 });
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -224,8 +224,9 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
  * e.g. "revert-572-revert-571-romain/bac-39" → { depth: 2, inner: "romain/bac-39" }
  */
 export function parseRevertBranch(branchName: string): { depth: number; inner: string } {
-  // Full refs can have org/ prefixes (e.g. "org/revert-571-..."), strip to the revert pattern
-  let name = branchName.replace(/^.*\/(?=revert-\d+-)/i, "");
+  // Full refs can have org/ prefixes (e.g. "org/revert-571-..."), strip to the revert pattern.
+  // Non-greedy so we stop at the first revert-N- match, not the last (preserves nested depth).
+  let name = branchName.replace(/^.*?\/(?=revert-\d+-)/i, "");
   let depth = 0;
   while (/^revert-\d+-/i.test(name)) {
     name = name.replace(/^revert-\d+-/i, "");

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -219,11 +219,7 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
   return [...new Set(prNumbers)];
 }
 
-/**
- * Strip revert-N- prefixes from a branch name and count nesting depth.
- * e.g. "revert-572-revert-571-romain/bac-39" → { depth: 2, inner: "romain/bac-39" }
- */
-export function parseRevertBranch(branchName: string): { depth: number; inner: string } {
+function parseRevertBranch(branchName: string): { depth: number; inner: string } {
   // Full refs can have org/ prefixes (e.g. "org/revert-571-..."), strip to the revert pattern.
   // Non-greedy so we stop at the first revert-N- match, not the last (preserves nested depth).
   let name = branchName.replace(/^.*?\/(?=revert-\d+-)/i, "");
@@ -235,16 +231,16 @@ export function parseRevertBranch(branchName: string): { depth: number; inner: s
   return { depth, inner: name };
 }
 
+/**
+ * Strip revert-N- prefixes from a branch name and count nesting depth.
+ * e.g. "revert-572-revert-571-romain/bac-39" → { depth: 2, inner: "romain/bac-39" }
+ */
 export function getRevertBranchDepth(branchName: string | null | undefined): number {
   if (!branchName) return 0;
   return parseRevertBranch(branchName).depth;
 }
 
-/**
- * Unwrap Revert "..." layers from a commit message and count nesting depth.
- * e.g. 'Revert "Revert "DRIVE-320: Fix""' → { depth: 2, inner: "DRIVE-320: Fix" }
- */
-export function parseRevertMessage(message: string): { depth: number; inner: string } {
+function parseRevertMessage(message: string): { depth: number; inner: string } {
   let text = message;
   let depth = 0;
   while (/^Revert "/i.test(text)) {
@@ -256,6 +252,10 @@ export function parseRevertMessage(message: string): { depth: number; inner: str
   return { depth, inner: text };
 }
 
+/**
+ * Unwrap Revert "..." layers from a commit message and count nesting depth.
+ * e.g. 'Revert "Revert "DRIVE-320: Fix""' → { depth: 2, inner: "DRIVE-320: Fix" }
+ */
 export function getRevertMessageDepth(message: string | null | undefined): number {
   if (!message) return 0;
   return parseRevertMessage(message).depth;


### PR DESCRIPTION
Replaces binary revert detection (`revert-\d+-` regex) with depth-aware parsing. Fixes two bugs: 
- revert-of-revert incorrectly blocked
- message-only reverts with magic words incorrectly added (e.g. `Revert "Fixes LIN-XXX"`)

Fixes LIN-61270