### PR TITLE
Proper revert extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-release",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "CLI tool to integrate CI/CD pipelines with Linear releases",
   "homepage": "https://github.com/linear/linear-release",

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -467,14 +467,6 @@ describe("extractRevertedIssueIdentifiersForCommit", () => {
     expect(ids(result)).toEqual([]);
   });
 
-  it("ignores non-issue tokens in unwrapped message", () => {
-    const result = extractRevertedIssueIdentifiersForCommit({
-      sha: "abc",
-      message: 'Revert "Bump v1-2 to v1-3"',
-    });
-    expect(ids(result)).toEqual([]);
-  });
-
   it("extracts identifier from revert branch name", () => {
     const result = extractRevertedIssueIdentifiersForCommit({
       sha: "abc",
@@ -521,104 +513,6 @@ describe("extractRevertedIssueIdentifiersForCommit", () => {
   it("returns empty for null/undefined inputs", () => {
     expect(ids(extractRevertedIssueIdentifiersForCommit({ sha: "abc", message: null }))).toEqual([]);
     expect(ids(extractRevertedIssueIdentifiersForCommit({ sha: "abc" }))).toEqual([]);
-  });
-});
-
-describe("revert chain: add → revert → re-add", () => {
-  const mergeAdd: CommitContext = {
-    sha: "c7f3c4b1",
-    branchName: "romain/bac-39",
-    message: "Merge pull request #571 from org/romain/bac-39 Add TEST variable",
-  };
-  const innerAdd: CommitContext = {
-    sha: "439fe0e5",
-    message: "Add TEST variable to .env.example",
-  };
-  const mergeRevert: CommitContext = {
-    sha: "69c6d923",
-    branchName: "revert-571-romain/bac-39",
-    message: 'Merge pull request #572 from org/revert-571-romain/bac-39 Revert "Add TEST variable"',
-  };
-  const innerRevert: CommitContext = {
-    sha: "986e4383",
-    message: 'Revert "Add TEST variable to .env.example"',
-  };
-  const mergeReAdd: CommitContext = {
-    sha: "cc13b9c5",
-    branchName: "revert-572-revert-571-romain/bac-39",
-    message: "Merge pull request #573 from org/revert-572-revert-571-romain/bac-39 Custom name for the revert revert",
-  };
-  const innerReAdd: CommitContext = {
-    sha: "9c83cecb",
-    message: 'Revert "Revert "Add TEST variable to .env.example""',
-  };
-  const inlineAdd: CommitContext = { sha: "c041d48b", message: "More revert test" };
-  const inlineRevert: CommitContext = { sha: "fa20f72f", message: 'Revert "More revert test"' };
-  const inlineReapply: CommitContext = { sha: "1086658b", message: 'Reapply "More revert test"' };
-  const inlineMerge: CommitContext = {
-    sha: "f685bbbc",
-    branchName: "romain/test-revert",
-    message: 'Merge pull request #575 from org/romain/test-revert Reapply "More revert test"',
-  };
-
-  describe("issue extraction (add path)", () => {
-    it("merge add → extracts identifier from branch", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(mergeAdd))).toEqual(["BAC-39"]);
-    });
-
-    it("inner add → nothing (no magic word, no branch)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(innerAdd))).toEqual([]);
-    });
-
-    it("merge revert → blocked (odd-depth revert branch)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(mergeRevert))).toEqual([]);
-    });
-
-    it("inner revert → nothing (Revert message has no magic word)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(innerRevert))).toEqual([]);
-    });
-
-    it("merge re-add → identifier re-added (even depth = revert-of-revert)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(mergeReAdd))).toEqual(["BAC-39"]);
-    });
-
-    it("inner re-add → nothing (no magic word, no branch)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(innerReAdd))).toEqual([]);
-    });
-
-    it("inline revert/reapply → nothing (no identifiers)", () => {
-      expect(ids(extractLinearIssueIdentifiersForCommit(inlineAdd))).toEqual([]);
-      expect(ids(extractLinearIssueIdentifiersForCommit(inlineRevert))).toEqual([]);
-      expect(ids(extractLinearIssueIdentifiersForCommit(inlineReapply))).toEqual([]);
-      expect(ids(extractLinearIssueIdentifiersForCommit(inlineMerge))).toEqual([]);
-    });
-  });
-
-  describe("issue extraction (revert path)", () => {
-    it("merge add → not a revert", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(mergeAdd))).toEqual([]);
-    });
-
-    it("merge revert → extracts identifier from stripped branch", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(mergeRevert))).toEqual(["BAC-39"]);
-    });
-
-    it("inner revert → nothing (no identifier in unwrapped message)", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(innerRevert))).toEqual([]);
-    });
-
-    it("merge re-add → not a revert (even depth)", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(mergeReAdd))).toEqual([]);
-    });
-
-    it("inner re-add → not a revert (even depth)", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(innerReAdd))).toEqual([]);
-    });
-
-    it("inline revert/reapply → nothing (no identifiers)", () => {
-      expect(ids(extractRevertedIssueIdentifiersForCommit(inlineRevert))).toEqual([]);
-      expect(ids(extractRevertedIssueIdentifiersForCommit(inlineReapply))).toEqual([]);
-    });
   });
 });
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -281,20 +281,20 @@ export function extractRevertedIssueIdentifiersForCommit(commit: CommitContext):
 
   const found = new Map<string, ExtractedIdentifier>();
 
+  if (branchDepth % 2 === 1) {
+    for (const match of matchAllIdentifiers(originalBranch)) {
+      if (!found.has(match.identifier)) {
+        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
+      }
+    }
+  }
+
   // Use magic-word gating on the inner message, same as the add path, to avoid
   // false positives from generic word-number tokens (e.g. "Bump v1-2 to v1-3").
   if (messageDepth % 2 === 1) {
     for (const match of matchMagicWordIdentifiers(innerMessage)) {
       if (!found.has(match.identifier)) {
         found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
-      }
-    }
-  }
-
-  if (branchDepth % 2 === 1) {
-    for (const match of matchAllIdentifiers(originalBranch)) {
-      if (!found.has(match.identifier)) {
-        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
       }
     }
   }

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -19,7 +19,8 @@ const ISSUE_IDENTIFIER_REGEX = new RegExp(
   "gi",
 );
 
-const LINEAR_ISSUE_URL_REGEX = /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-[0-9]{1,9})(?:\/[\w-]*)*/gi;
+const LINEAR_ISSUE_URL_REGEX =
+  /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-[0-9]{1,9})(?:\/[\w-]*)*/gi;
 
 function normalizeLinearUrls(text: string): string {
   return text.replace(LINEAR_ISSUE_URL_REGEX, "$1");
@@ -82,7 +83,12 @@ type IdentifierMatch = {
 function parseMatch(match: RegExpExecArray): IdentifierMatch | undefined {
   const [, rawIdentifier, teamKey, numberString] = match;
   // Reject leading zeros (e.g., LIN-0004)
-  if (!rawIdentifier || !teamKey || !numberString || Number(numberString).toString().length !== numberString.length) {
+  if (
+    !rawIdentifier ||
+    !teamKey ||
+    !numberString ||
+    Number(numberString).toString().length !== numberString.length
+  ) {
     return;
   }
   return {
@@ -129,21 +135,29 @@ function matchMagicWordIdentifiers(text: string): IdentifierMatch[] {
   return results;
 }
 
-export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): string[] {
+export function extractLinearIssueIdentifiersForCommit(
+  commit: CommitContext,
+): string[] {
   if (!commit) {
     return [];
   }
 
   // Odd depth = the commit is undoing previous work (a revert), so we must not
   // count its identifiers as "added". Even depth = revert-of-revert (re-add).
-  const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(commit.branchName ?? "");
+  const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(
+    commit.branchName ?? "",
+  );
   if (branchDepth % 2 === 1) {
-    log(`Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`);
+    log(
+      `Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`,
+    );
     return [];
   }
   const { depth: messageDepth } = parseRevertMessage(commit.message ?? "");
   if (messageDepth % 2 === 1) {
-    log(`Skipping revert message (depth ${messageDepth}) for commit ${commit.sha}`);
+    log(
+      `Skipping revert message (depth ${messageDepth}) for commit ${commit.sha}`,
+    );
     return [];
   }
 
@@ -170,7 +184,9 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): s
   return Array.from(found.keys());
 }
 
-export function extractPullRequestNumbersForCommit(commit: CommitContext): number[] {
+export function extractPullRequestNumbersForCommit(
+  commit: CommitContext,
+): number[] {
   if (!commit) {
     return [];
   }
@@ -196,14 +212,18 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
   const title = message.split(/\r?\n/)[0] ?? "";
   const squashMatch = title.match(/\(#(\d+)\)$/);
   if (squashMatch) {
-    log(`Found PR number ${squashMatch[1]} in commit ${commit.sha} using squash format: "${message}"`);
+    log(
+      `Found PR number ${squashMatch[1]} in commit ${commit.sha} using squash format: "${message}"`,
+    );
     prNumbers.push(Number.parseInt(squashMatch[1]!, 10));
   }
 
   // GitHub merge: "Merge pull request #123 from ..." - must be at start
   const mergeMatch = message.match(/^Merge pull request #(\d+)/i);
   if (mergeMatch) {
-    log(`Found PR number ${mergeMatch[1]} in commit ${commit.sha} using merge format: "${message}"`);
+    log(
+      `Found PR number ${mergeMatch[1]} in commit ${commit.sha} using merge format: "${message}"`,
+    );
     prNumbers.push(Number.parseInt(mergeMatch[1]!, 10));
   }
 
@@ -211,7 +231,9 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
   if (prNumbers.length === 0) {
     const messageMatches = message.matchAll(/#(\d+)/g);
     for (const match of messageMatches) {
-      log(`Found PR number ${match[1]} in commit ${commit.sha} by extracting from message: "${message}"`);
+      log(
+        `Found PR number ${match[1]} in commit ${commit.sha} by extracting from message: "${message}"`,
+      );
       prNumbers.push(Number.parseInt(match[1]!, 10));
     }
   }
@@ -238,7 +260,9 @@ function parseRevertBranch(branchName: string): {
  * Strip revert-N- prefixes from a branch name and count nesting depth.
  * e.g. "revert-572-revert-571-romain/bac-39" → { depth: 2, inner: "romain/bac-39" }
  */
-export function getRevertBranchDepth(branchName: string | null | undefined): number {
+export function getRevertBranchDepth(
+  branchName: string | null | undefined,
+): number {
   if (!branchName) return 0;
   return parseRevertBranch(branchName).depth;
 }
@@ -259,7 +283,9 @@ function parseRevertMessage(message: string): { depth: number; inner: string } {
  * Unwrap Revert "..." layers from a commit message and count nesting depth.
  * e.g. 'Revert "Revert "DRIVE-320: Fix""' → { depth: 2, inner: "DRIVE-320: Fix" }
  */
-export function getRevertMessageDepth(message: string | null | undefined): number {
+export function getRevertMessageDepth(
+  message: string | null | undefined,
+): number {
   if (!message) return 0;
   return parseRevertMessage(message).depth;
 }

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -219,7 +219,10 @@ export function extractPullRequestNumbersForCommit(commit: CommitContext): numbe
   return [...new Set(prNumbers)];
 }
 
-function parseRevertBranch(branchName: string): { depth: number; inner: string } {
+function parseRevertBranch(branchName: string): {
+  depth: number;
+  inner: string;
+} {
   // Full refs can have org/ prefixes (e.g. "org/revert-571-..."), strip to the revert pattern.
   // Non-greedy so we stop at the first revert-N- match, not the last (preserves nested depth).
   let name = branchName.replace(/^.*?\/(?=revert-\d+-)/i, "");

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -19,8 +19,7 @@ const ISSUE_IDENTIFIER_REGEX = new RegExp(
   "gi",
 );
 
-const LINEAR_ISSUE_URL_REGEX =
-  /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-[0-9]{1,9})(?:\/[\w-]*)*/gi;
+const LINEAR_ISSUE_URL_REGEX = /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-[0-9]{1,9})(?:\/[\w-]*)*/gi;
 
 function normalizeLinearUrls(text: string): string {
   return text.replace(LINEAR_ISSUE_URL_REGEX, "$1");
@@ -83,12 +82,7 @@ type IdentifierMatch = {
 function parseMatch(match: RegExpExecArray): IdentifierMatch | undefined {
   const [, rawIdentifier, teamKey, numberString] = match;
   // Reject leading zeros (e.g., LIN-0004)
-  if (
-    !rawIdentifier ||
-    !teamKey ||
-    !numberString ||
-    Number(numberString).toString().length !== numberString.length
-  ) {
+  if (!rawIdentifier || !teamKey || !numberString || Number(numberString).toString().length !== numberString.length) {
     return;
   }
   return {
@@ -135,38 +129,35 @@ function matchMagicWordIdentifiers(text: string): IdentifierMatch[] {
   return results;
 }
 
-export function extractLinearIssueIdentifiersForCommit(
-  commit: CommitContext,
-): string[] {
+export type ExtractedIdentifier = {
+  identifier: string;
+  source: "branch_name" | "commit_message";
+};
+
+export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): ExtractedIdentifier[] {
   if (!commit) {
     return [];
   }
 
   // Odd depth = the commit is undoing previous work (a revert), so we must not
   // count its identifiers as "added". Even depth = revert-of-revert (re-add).
-  const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(
-    commit.branchName ?? "",
-  );
+  const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(commit.branchName ?? "");
   if (branchDepth % 2 === 1) {
-    log(
-      `Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`,
-    );
+    log(`Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`);
     return [];
   }
   const { depth: messageDepth } = parseRevertMessage(commit.message ?? "");
   if (messageDepth % 2 === 1) {
-    log(
-      `Skipping revert message (depth ${messageDepth}) for commit ${commit.sha}`,
-    );
+    log(`Skipping revert message (depth ${messageDepth}) for commit ${commit.sha}`);
     return [];
   }
 
-  const found = new Map<string, string>();
+  const found = new Map<string, ExtractedIdentifier>();
 
   if (strippedBranch.length > 0) {
     for (const match of matchAllIdentifiers(strippedBranch)) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, match.rawIdentifier);
+        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
       }
     }
   }
@@ -176,17 +167,15 @@ export function extractLinearIssueIdentifiersForCommit(
   if (message.length > 0) {
     for (const match of matchMagicWordIdentifiers(message)) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, match.rawIdentifier);
+        found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
       }
     }
   }
 
-  return Array.from(found.keys());
+  return Array.from(found.values());
 }
 
-export function extractPullRequestNumbersForCommit(
-  commit: CommitContext,
-): number[] {
+export function extractPullRequestNumbersForCommit(commit: CommitContext): number[] {
   if (!commit) {
     return [];
   }
@@ -212,18 +201,14 @@ export function extractPullRequestNumbersForCommit(
   const title = message.split(/\r?\n/)[0] ?? "";
   const squashMatch = title.match(/\(#(\d+)\)$/);
   if (squashMatch) {
-    log(
-      `Found PR number ${squashMatch[1]} in commit ${commit.sha} using squash format: "${message}"`,
-    );
+    log(`Found PR number ${squashMatch[1]} in commit ${commit.sha} using squash format: "${message}"`);
     prNumbers.push(Number.parseInt(squashMatch[1]!, 10));
   }
 
   // GitHub merge: "Merge pull request #123 from ..." - must be at start
   const mergeMatch = message.match(/^Merge pull request #(\d+)/i);
   if (mergeMatch) {
-    log(
-      `Found PR number ${mergeMatch[1]} in commit ${commit.sha} using merge format: "${message}"`,
-    );
+    log(`Found PR number ${mergeMatch[1]} in commit ${commit.sha} using merge format: "${message}"`);
     prNumbers.push(Number.parseInt(mergeMatch[1]!, 10));
   }
 
@@ -231,9 +216,7 @@ export function extractPullRequestNumbersForCommit(
   if (prNumbers.length === 0) {
     const messageMatches = message.matchAll(/#(\d+)/g);
     for (const match of messageMatches) {
-      log(
-        `Found PR number ${match[1]} in commit ${commit.sha} by extracting from message: "${message}"`,
-      );
+      log(`Found PR number ${match[1]} in commit ${commit.sha} by extracting from message: "${message}"`);
       prNumbers.push(Number.parseInt(match[1]!, 10));
     }
   }
@@ -260,9 +243,7 @@ function parseRevertBranch(branchName: string): {
  * Strip revert-N- prefixes from a branch name and count nesting depth.
  * e.g. "revert-572-revert-571-romain/bac-39" → { depth: 2, inner: "romain/bac-39" }
  */
-export function getRevertBranchDepth(
-  branchName: string | null | undefined,
-): number {
+export function getRevertBranchDepth(branchName: string | null | undefined): number {
   if (!branchName) return 0;
   return parseRevertBranch(branchName).depth;
 }
@@ -283,9 +264,40 @@ function parseRevertMessage(message: string): { depth: number; inner: string } {
  * Unwrap Revert "..." layers from a commit message and count nesting depth.
  * e.g. 'Revert "Revert "DRIVE-320: Fix""' → { depth: 2, inner: "DRIVE-320: Fix" }
  */
-export function getRevertMessageDepth(
-  message: string | null | undefined,
-): number {
+export function getRevertMessageDepth(message: string | null | undefined): number {
   if (!message) return 0;
   return parseRevertMessage(message).depth;
+}
+
+/** Extract identifiers being reverted. Returns [] if not an odd-depth revert. */
+export function extractRevertedIssueIdentifiersForCommit(commit: CommitContext): ExtractedIdentifier[] {
+  if (!commit) return [];
+
+  const { depth: branchDepth, inner: originalBranch } = parseRevertBranch(commit.branchName ?? "");
+  const { depth: messageDepth, inner: innerMessage } = parseRevertMessage(commit.message ?? "");
+
+  // At least one of branch/message must have odd depth (i.e., be a revert) to extract
+  if (branchDepth % 2 === 0 && messageDepth % 2 === 0) return [];
+
+  const found = new Map<string, ExtractedIdentifier>();
+
+  // Use magic-word gating on the inner message, same as the add path, to avoid
+  // false positives from generic word-number tokens (e.g. "Bump v1-2 to v1-3").
+  if (messageDepth % 2 === 1) {
+    for (const match of matchMagicWordIdentifiers(innerMessage)) {
+      if (!found.has(match.identifier)) {
+        found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
+      }
+    }
+  }
+
+  if (branchDepth % 2 === 1) {
+    for (const match of matchAllIdentifiers(originalBranch)) {
+      if (!found.has(match.identifier)) {
+        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
+      }
+    }
+  }
+
+  return Array.from(found.values());
 }

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+import { scanCommits } from "./scan";
+import { CommitContext } from "./types";
+
+function ids(refs: { identifier: string }[]): string[] {
+  return refs.map((r) => r.identifier).sort();
+}
+
+describe("scanCommits", () => {
+  describe("add → revert → re-add chain", () => {
+    // Oldest first, as scanCommits expects
+    const commits: CommitContext[] = [
+      { sha: "a1", message: "Add TEST variable to .env.example" },
+      {
+        sha: "a2",
+        branchName: "romain/bac-39",
+        message: "Merge pull request #571 from org/romain/bac-39 Add TEST variable",
+      },
+      { sha: "r1", message: 'Revert "Add TEST variable to .env.example"' },
+      {
+        sha: "r2",
+        branchName: "revert-571-romain/bac-39",
+        message: 'Merge pull request #572 from org/revert-571-romain/bac-39 Revert "Add TEST variable"',
+      },
+      { sha: "ra1", message: 'Revert "Revert "Add TEST variable to .env.example""' },
+      {
+        sha: "ra2",
+        branchName: "revert-572-revert-571-romain/bac-39",
+        message: "Merge pull request #573 from org/revert-572-revert-571-romain/bac-39 Custom name",
+      },
+    ];
+
+    it("full chain: last action is re-add, so identifier is in added list", () => {
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual(["BAC-39"]);
+      expect(ids(result.revertedIssueReferences)).toEqual([]);
+    });
+
+    it("add only: identifier is in added list", () => {
+      const result = scanCommits(commits.slice(0, 2), null);
+      expect(ids(result.issueReferences)).toEqual(["BAC-39"]);
+      expect(ids(result.revertedIssueReferences)).toEqual([]);
+    });
+
+    it("add + revert: identifier is in reverted list", () => {
+      const result = scanCommits(commits.slice(0, 4), null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["BAC-39"]);
+    });
+  });
+
+  describe("squash revert with magic word in message", () => {
+    it("identifier extracted from unwrapped message via magic word, ends up reverted", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", message: "Fixes DRIVE-320: memory leak in background location service" },
+        { sha: "r1", message: 'Revert "Fixes DRIVE-320: memory leak in background location service"' },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["DRIVE-320"]);
+    });
+
+    it("identifier without magic word is ignored (no false positives)", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", message: "Bump v1-2 to v1-3" },
+        { sha: "r1", message: 'Revert "Bump v1-2 to v1-3"' },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual([]);
+    });
+  });
+
+  describe("inline revert/reapply cycle without identifiers", () => {
+    const commits: CommitContext[] = [
+      { sha: "a1", message: "More revert test" },
+      { sha: "r1", message: 'Revert "More revert test"' },
+      { sha: "ra1", message: 'Reapply "More revert test"' },
+      {
+        sha: "m1",
+        branchName: "romain/test-revert",
+        message: 'Merge pull request #575 from org/romain/test-revert Reapply "More revert test"',
+      },
+    ];
+
+    it("no identifiers found in either list", () => {
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual([]);
+    });
+  });
+
+  describe("last-write-wins edge cases", () => {
+    it("different issues go to their respective lists", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", branchName: "user/eng-100", message: "Fixes ENG-100" },
+        { sha: "r1", branchName: "revert-1-user/eng-200", message: 'Revert "ENG-200: something"' },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual(["ENG-100"]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["ENG-200"]);
+    });
+
+    it("add then revert same issue: only in reverted", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", branchName: "user/eng-100" },
+        { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
+    });
+
+    it("revert then add same issue: only in added", () => {
+      const commits: CommitContext[] = [
+        { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
+        { sha: "a1", branchName: "user/eng-100" },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual(["ENG-100"]);
+      expect(ids(result.revertedIssueReferences)).toEqual([]);
+    });
+
+    it("revert merge commit with magic word in message does not add identifier", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", branchName: "user/eng-100" },
+        {
+          sha: "r1",
+          branchName: "revert-1-user/eng-100",
+          message: "Merge pull request #2\n\nFixes ENG-100",
+        },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
+    });
+
+    it("message-only revert with magic word is reverted, not added", () => {
+      const commits: CommitContext[] = [
+        { sha: "a1", branchName: "user/eng-100", message: "Fixes ENG-100" },
+        { sha: "r1", message: 'Revert "Fixes ENG-100"' },
+      ];
+      const result = scanCommits(commits, null);
+      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
+    });
+  });
+});

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -30,19 +30,19 @@ describe("scanCommits", () => {
       },
     ];
 
-    it("full chain: last action is re-add, so identifier is in added list", () => {
+    it("adds identifier when last action is re-add", () => {
       const result = scanCommits(commits, null);
       expect(ids(result.issueReferences)).toEqual(["BAC-39"]);
       expect(ids(result.revertedIssueReferences)).toEqual([]);
     });
 
-    it("add only: identifier is in added list", () => {
+    it("adds identifier when only add commits are present", () => {
       const result = scanCommits(commits.slice(0, 2), null);
       expect(ids(result.issueReferences)).toEqual(["BAC-39"]);
       expect(ids(result.revertedIssueReferences)).toEqual([]);
     });
 
-    it("add + revert: identifier is in reverted list", () => {
+    it("reverts identifier when add is followed by revert", () => {
       const result = scanCommits(commits.slice(0, 4), null);
       expect(ids(result.issueReferences)).toEqual([]);
       expect(ids(result.revertedIssueReferences)).toEqual(["BAC-39"]);
@@ -50,7 +50,7 @@ describe("scanCommits", () => {
   });
 
   describe("squash revert with magic word in message", () => {
-    it("identifier extracted from unwrapped message via magic word, ends up reverted", () => {
+    it("reverts identifier extracted from unwrapped message via magic word", () => {
       const commits: CommitContext[] = [
         { sha: "a1", message: "Fixes DRIVE-320: memory leak in background location service" },
         { sha: "r1", message: 'Revert "Fixes DRIVE-320: memory leak in background location service"' },
@@ -60,7 +60,7 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual(["DRIVE-320"]);
     });
 
-    it("identifier without magic word is ignored (no false positives)", () => {
+    it("ignores version-like tokens (v1-2) without magic word", () => {
       const commits: CommitContext[] = [
         { sha: "a1", message: "Bump v1-2 to v1-3" },
         { sha: "r1", message: 'Revert "Bump v1-2 to v1-3"' },
@@ -72,7 +72,7 @@ describe("scanCommits", () => {
   });
 
   describe("last-write-wins edge cases", () => {
-    it("different issues go to their respective lists", () => {
+    it("separates different issues into added and reverted lists", () => {
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100", message: "Fixes ENG-100" },
         { sha: "r1", branchName: "revert-1-user/eng-200", message: 'Revert "ENG-200: something"' },
@@ -82,7 +82,7 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual(["ENG-200"]);
     });
 
-    it("add then revert same issue: only in reverted", () => {
+    it("reverts when same issue is added then reverted", () => {
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100" },
         { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
@@ -92,7 +92,7 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
     });
 
-    it("revert then add same issue: only in added", () => {
+    it("adds when same issue is reverted then re-added", () => {
       const commits: CommitContext[] = [
         { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
         { sha: "a1", branchName: "user/eng-100" },
@@ -102,7 +102,9 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual([]);
     });
 
-    it("revert merge commit with magic word in message does not add identifier", () => {
+    it("reverts despite magic word in message when branch signals revert", () => {
+      // The branch name (revert-1-...) signals this is a revert, even though
+      // the message body contains "Fixes ENG-100" which would normally add it.
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100" },
         {
@@ -116,7 +118,7 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
     });
 
-    it("message-only revert with magic word is reverted, not added", () => {
+    it("reverts via message-only revert even when previously added from branch", () => {
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100", message: "Fixes ENG-100" },
         { sha: "r1", message: 'Revert "Fixes ENG-100"' },

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -71,25 +71,6 @@ describe("scanCommits", () => {
     });
   });
 
-  describe("inline revert/reapply cycle without identifiers", () => {
-    const commits: CommitContext[] = [
-      { sha: "a1", message: "More revert test" },
-      { sha: "r1", message: 'Revert "More revert test"' },
-      { sha: "ra1", message: 'Reapply "More revert test"' },
-      {
-        sha: "m1",
-        branchName: "romain/test-revert",
-        message: 'Merge pull request #575 from org/romain/test-revert Reapply "More revert test"',
-      },
-    ];
-
-    it("no identifiers found in either list", () => {
-      const result = scanCommits(commits, null);
-      expect(ids(result.issueReferences)).toEqual([]);
-      expect(ids(result.revertedIssueReferences)).toEqual([]);
-    });
-  });
-
   describe("last-write-wins edge cases", () => {
     it("different issues go to their respective lists", () => {
       const commits: CommitContext[] = [

--- a/src/types.ts
+++ b/src/types.ts
@@ -104,6 +104,7 @@ export type PullRequestSource = {
 export type DebugSink = {
   inspectedShas: string[]; // From oldest to newest
   issues: Record<string, IssueSource[]>; // Issue identifier -> array of sources
+  revertedIssues: Record<string, IssueSource[]>; // Issue identifier -> array of sources (reverted)
   pullRequests: PullRequestSource[]; // PR numbers found in commits
   includePaths: string[] | null; // Path filters applied during commit scanning
 };


### PR DESCRIPTION
Main thing this PR is doing:

1. **Revert extraction** — New `extractRevertedIssueIdentifiersForCommit` function that unwraps revert layers and extracts the identifiers being reverted.
2. **Last-write-wins aggregation** — `scanCommits` processes commits oldest-first; for each identifier, the chronologically last action (added or reverted) determines the final state. The result is sent to the API as `issueReferences` + `revertedIssueReferences`.

Fixes LIN-61281

PR to handle this in the API: