### PR TITLE
Add release script to handle releases automatically

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -1,0 +1,52 @@
+name: Auto-tag release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    name: Create release tag
+    runs-on: ubuntu-latest
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Extract and validate version
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          VERSION="${BRANCH#release/}"
+
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Branch version ($VERSION) does not match package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+          if git tag -l "v$VERSION" | grep -q .; then
+            echo "::error::Tag v$VERSION already exists"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.version.outputs.version }}"
+          git push origin "v${{ steps.version.outputs.version }}"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt --write",
     "fmt:check": "oxfmt --check",
+    "release": "./scripts/release.sh",
     "prepare": "[ \"$CI\" = \"true\" ] || (git config --unset core.hooksPath 2>/dev/null || true; lefthook install)"
   },
   "dependencies": {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+
+# --- Usage ---
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.7.0"
+  exit 1
+fi
+
+# --- Validate version format ---
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Error: Invalid version format '$VERSION'. Expected MAJOR.MINOR.PATCH (e.g., 0.7.0)"
+  exit 1
+fi
+
+# --- Preflight checks ---
+
+# gh CLI
+if ! command -v gh &>/dev/null; then
+  echo "Error: gh CLI is not installed. Install it from https://cli.github.com"
+  exit 1
+fi
+if ! gh auth status &>/dev/null; then
+  echo "Error: gh CLI is not authenticated. Run 'gh auth login' first."
+  exit 1
+fi
+
+# Clean working tree
+if [ -n "$(git status --porcelain)" ]; then
+  echo "Error: Working tree is not clean. Commit or stash your changes first."
+  exit 1
+fi
+
+# Must be on main
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "main" ]; then
+  echo "Error: Must be on 'main' branch (currently on '$CURRENT_BRANCH')."
+  exit 1
+fi
+
+# Up to date with origin/main
+git fetch origin main --quiet
+LOCAL_SHA=$(git rev-parse main)
+REMOTE_SHA=$(git rev-parse origin/main)
+if [ "$LOCAL_SHA" != "$REMOTE_SHA" ]; then
+  echo "Error: Local 'main' is not up to date with 'origin/main'. Run 'git pull' first."
+  exit 1
+fi
+
+# Tag must not exist
+if git tag -l "v$VERSION" | grep -q .; then
+  echo "Error: Tag 'v$VERSION' already exists."
+  exit 1
+fi
+
+# Branch must not exist (local or remote)
+BRANCH="release/$VERSION"
+if git show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
+  echo "Error: Local branch '$BRANCH' already exists."
+  exit 1
+fi
+if git ls-remote --exit-code --heads origin "$BRANCH" &>/dev/null; then
+  echo "Error: Remote branch '$BRANCH' already exists."
+  exit 1
+fi
+
+# --- Create release branch and bump version ---
+echo "Creating branch '$BRANCH'..."
+git checkout -b "$BRANCH"
+
+echo "Bumping package.json to $VERSION..."
+VERSION="$VERSION" node -e '
+  const fs = require("fs");
+  const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+  pkg.version = process.env.VERSION;
+  fs.writeFileSync("package.json", JSON.stringify(pkg, null, 2) + "\n");
+'
+
+git add package.json
+git commit -m "Bump package.json to $VERSION"
+
+# --- Push and create PR ---
+echo "Pushing branch..."
+git push -u origin "$BRANCH"
+
+echo "Creating pull request..."
+PR_URL=$(gh pr create \
+  --title "Bump package.json to $VERSION" \
+  --body "Release $VERSION
+
+After this PR is merged, the \`v$VERSION\` tag will be created automatically, triggering the release workflow." \
+  --base main)
+
+echo ""
+echo "PR created: $PR_URL"
+echo "Once merged, the tag 'v$VERSION' will be created automatically and the release workflow will run."


### PR DESCRIPTION
## Flow

1. Run `pnpm release 0.7.0` from a clean, up-to-date local main
2. The script creates `release/0.7.0`, bumps `package.json`, pushes, and opens a PR to main
3. After that PR is merged, GitHub Actions validates the version and creates tag `v0.7.0`
4. The existing tag-based release workflow publishes the binaries and completes the release

## Notes

* The auto-tag workflow is limited to same-repo release/\* PRs