### PR TITLE
Support Bitbucket merge format

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -304,6 +304,18 @@ describe("extractBranchNameFromMergeMessage", () => {
     });
   });
 
+  describe("Bitbucket format", () => {
+    it("should extract branch name from standard Bitbucket merge message", () => {
+      const message = "Merged in romain/LIN-123-fix-auth (pull request #42)";
+      expect(extractBranchNameFromMergeMessage(message)).toBe("romain/LIN-123-fix-auth");
+    });
+
+    it("should extract branch name and ignore trailing PR title", () => {
+      const message = "Merged in feature/ENG-123-add-button (pull request #7) Improve button spacing";
+      expect(extractBranchNameFromMergeMessage(message)).toBe("feature/ENG-123-add-button");
+    });
+  });
+
   describe("edge cases", () => {
     it("should return null for non-merge messages", () => {
       expect(extractBranchNameFromMergeMessage("Some regular commit")).toBeNull();

--- a/src/git.ts
+++ b/src/git.ts
@@ -137,6 +137,7 @@ export function isMergeCommit(sha: string, cwd: string = process.cwd()): boolean
  *   - GitHub: "Merge pull request #X from owner/branch-name"
  *   - GitLab: "Merge branch 'branch-name' into 'target'"
  *   - GitLab (no target): "Merge branch 'branch-name'"
+ *   - Bitbucket: "Merged in branch-name (pull request #X)"
  */
 export function extractBranchNameFromMergeMessage(message: string | null | undefined): string | null {
   if (!message) {
@@ -149,7 +150,12 @@ export function extractBranchNameFromMergeMessage(message: string | null | undef
   }
   // GitLab: "Merge branch 'branch-name' into 'target'" or "Merge branch 'branch-name'"
   const gitlabMatch = message.match(/Merge branch '([^']+)'/i);
-  return gitlabMatch?.[1] ?? null;
+  if (gitlabMatch?.[1]) {
+    return gitlabMatch[1];
+  }
+  // Bitbucket: "Merged in feature/ENG-123-fix-auth (pull request #42)"
+  const bitbucketMatch = message.match(/Merged in (\S+) \(pull request #\d+\)/i);
+  return bitbucketMatch?.[1] ?? null;
 }
 
 /**


### PR DESCRIPTION
From https://support.atlassian.com/bitbucket-cloud/kb/understanding-the-default-pull-request-title-description-and-merge-commit-message/.