### PR TITLE
Dispatch release workflow directly from auto-tag one

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -15,6 +15,7 @@ jobs:
       startsWith(github.event.pull_request.head.ref, 'release/')
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,3 +51,9 @@ jobs:
         run: |
           git tag "v${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run release.yml --ref "v${{ steps.version.outputs.version }}"


### PR DESCRIPTION
The `auto-tag-release.yml` workflow pushes tags using `GITHUB_TOKEN`. GitHub doesn't trigger workflows from push events created by GITHUB_TOKEN. Previous releases worked because tags were pushed manually.

Fix: Added a step in `auto-tag-release.yml` that explicitly triggers `release.yml` via `gh workflow run` with the tag ref. `workflow_dispatch` is exempted from the `GITHUB_TOKEN` restriction, so this works