### PR TITLE
Add "implement(s)" as closing keyword

### DIFF
--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -246,6 +246,10 @@ describe("commit message magic word behavior", () => {
     "completes",
     "completed",
     "completing",
+    "implement",
+    "implements",
+    "implemented",
+    "implementing",
   ])("closing keyword '%s' extracts issue", (keyword) => {
     const result = extractLinearIssueIdentifiersForCommit({
       sha: "abc",

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -43,6 +43,10 @@ const CLOSING_WORDS = [
   "completes",
   "completed",
   "completing",
+  "implement",
+  "implements",
+  "implemented",
+  "implementing",
 ];
 
 /** Magic phrases that indicate a commit contributes to an issue. Matches Linear's detection. */


### PR DESCRIPTION
Adds `implement`, `implements`, `implemented`, and `implementing` to the `CLOSING_WORDS` array, matching the same change made in `linear-app`.