### PR TITLE
Fix shallow clone deepening hanging in CI

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -227,7 +227,7 @@ export function ensureCommitAvailable(sha: string, cwd: string = process.cwd()):
   for (const { command, label } of strategies) {
     verbose(label);
     try {
-      execSync(command, { cwd, stdio: "pipe" });
+      execSync(command, { cwd, stdio: ["ignore", "ignore", "pipe"], timeout: 30_000 });
       if (commitExists(sha, cwd)) {
         verbose(`Found commit ${sha}`);
         return;

--- a/src/git.ts
+++ b/src/git.ts
@@ -232,8 +232,9 @@ export function ensureCommitAvailable(sha: string, cwd: string = process.cwd()):
         verbose(`Found commit ${sha}`);
         return;
       }
-    } catch {
-      // Strategy failed, try next
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      verbose(`Strategy "${label}" failed: ${reason}`);
     }
   }
 


### PR DESCRIPTION
Something ended up hanging the deepening for linear-app ([example run](https://github.com/linear/linear-app/actions/runs/22956846019/job/66636321970)) so this is Claude and I's attempt to at least get that error visible so we can come up with a fix. I validated locally that automatic deepening works from a shallow repo, so it is likely something CI-related resulting in the deepening hanging.

**Changes:**
- `stdio: ["ignore", "ignore", "pipe"]` — closes stdin so git can't hang waiting for input
- `timeout: 30_000` — 30s hard timeout enforced at the OS level (SIGTERM), independent of the event loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Towards LIN-62864