### PR TITLE
Add Linux arm64 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,10 @@ jobs:
             arch: x64
             platform: linux-x64
             target: bun-linux-x64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+            platform: linux-arm64
+            target: bun-linux-arm64
           - os: macos-latest
             arch: x64
             platform: darwin-x64


### PR DESCRIPTION
Adding a linux based arm64 release allows running the tool in arm based runners, and allows building docker images with multi-arch support.