### PR TITLE
Recognize *.ghe.com hosts as GitHub Enterprise Cloud

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -251,6 +251,35 @@ describe("parseRepoUrl", () => {
     });
   });
 
+  describe("GitHub Enterprise Cloud (*.ghe.com)", () => {
+    it("should detect github provider for a *.ghe.com host", () => {
+      const result = parseRepoUrl("https://acme.ghe.com/engineering/platform.git");
+      expect(result).toEqual({
+        owner: "engineering",
+        name: "platform",
+        provider: "github",
+        url: "https://acme.ghe.com/engineering/platform",
+      });
+    });
+
+    it("should detect github provider for multi-part subdomains under .ghe.com", () => {
+      const result = parseRepoUrl("https://tenant-name.ghe.com/owner/repo.git");
+      expect(result?.provider).toBe("github");
+    });
+
+    it("should not match the bare ghe.com host (no subdomain)", () => {
+      const result = parseRepoUrl("https://ghe.com/owner/repo.git");
+      expect(result?.provider).toBeNull();
+    });
+
+    it("should not match hosts that merely contain .ghe.com as a substring", () => {
+      // Suffix match guards against attacker-controlled hosts that happen
+      // to include "ghe.com" somewhere in the middle of the hostname.
+      const result = parseRepoUrl("https://evil-ghe.com.attacker.com/owner/repo.git");
+      expect(result?.provider).toBeNull();
+    });
+  });
+
   describe("unknown providers", () => {
     it("should return null provider for unknown hosts", () => {
       const result = parseRepoUrl("https://example.com/myorg/myrepo.git");

--- a/src/git.ts
+++ b/src/git.ts
@@ -315,7 +315,7 @@ function hostToProvider(host: string): string | null {
   if (host === "gitlab.com" || host.includes("gitlab")) {
     return "gitlab";
   }
-  if (host === "github.com" || host.includes("github")) {
+  if (host === "github.com" || host.endsWith(".ghe.com") || host.includes("github")) {
     return "github";
   }
   return null;


### PR DESCRIPTION
## Summary
- Add `host.endsWith(".ghe.com")` to the github branch of `hostToProvider()`. Suffix match (not `includes`) so attacker-controlled hostnames like `evil-ghe.com.attacker.com` don't
false-positive.
- Add unit tests to cover positive (`acme.ghe.com`, `tenant-name.ghe.com`) and negative (bare `ghe.com`, substring) cases.

## Context
We hit this when running the action against a repo hosted on GitHub Enterprise Cloud with data residency (hostname under `*.ghe.com`). `hostToProvider()` returned `null` for the host, so the Linear API rejected the sync with:

> Variable `$input` got invalid value null at `input.repository.provider`;
> Expected non-nullable type `String!` not to be null.

As a quick workaround we rewrote the git remote to swap the `*.ghe.com` host for `github.com` so the URL would hit the existing github branch in `hostToProvider()`, however that results in the links to the repository from Linear not working correctly. GHE Cloud should be functionally equivalent to github.com for what the CLI cares about, e.g. the same PR-merge commit conventions hold (`Merge pull request #N from owner/branch`), so `extractBranchNameFromMergeMessage` and the rest of the pipeline work unchanged. 

[About GitHub Enterprise Cloud with data residency and GHE.com domains](https://docs.github.com/en/enterprise-cloud@latest/admin/data-residency/about-github-enterprise-cloud-with-data-residency)