### PR TITLE
Add Bitbucket provider support

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -188,6 +188,26 @@ describe("parseRepoUrl", () => {
       });
     });
 
+    it("should parse bitbucket.org HTTPS URL", () => {
+      const result = parseRepoUrl("https://bitbucket.org/myorg/myrepo.git");
+      expect(result).toEqual({
+        owner: "myorg",
+        name: "myrepo",
+        provider: "bitbucket",
+        url: "https://bitbucket.org/myorg/myrepo",
+      });
+    });
+
+    it("should parse self-hosted Bitbucket HTTPS URL", () => {
+      const result = parseRepoUrl("https://bitbucket.mycompany.com/team/service.git");
+      expect(result).toEqual({
+        owner: "team",
+        name: "service",
+        provider: "bitbucket",
+        url: "https://bitbucket.mycompany.com/team/service",
+      });
+    });
+
     it("should parse HTTPS URL with credentials", () => {
       const result = parseRepoUrl("https://token@github.com/linear/linear-app.git");
       expect(result).toEqual({
@@ -247,6 +267,26 @@ describe("parseRepoUrl", () => {
         name: "service",
         provider: "gitlab",
         url: "https://gitlab.internal.io/team/service",
+      });
+    });
+
+    it("should parse bitbucket.org SSH URL", () => {
+      const result = parseRepoUrl("git@bitbucket.org:myorg/myrepo.git");
+      expect(result).toEqual({
+        owner: "myorg",
+        name: "myrepo",
+        provider: "bitbucket",
+        url: "https://bitbucket.org/myorg/myrepo",
+      });
+    });
+
+    it("should parse self-hosted Bitbucket SSH URL", () => {
+      const result = parseRepoUrl("git@bitbucket.mycompany.com:team/service.git");
+      expect(result).toEqual({
+        owner: "team",
+        name: "service",
+        provider: "bitbucket",
+        url: "https://bitbucket.mycompany.com/team/service",
       });
     });
   });

--- a/src/git.ts
+++ b/src/git.ts
@@ -318,6 +318,9 @@ function hostToProvider(host: string): string | null {
   if (host === "github.com" || host.includes("github")) {
     return "github";
   }
+  if (host === "bitbucket.org" || host.includes("bitbucket")) {
+    return "bitbucket";
+  }
   return null;
 }
 


### PR DESCRIPTION
## Summary

- Add Bitbucket as a recognized provider in `hostToProvider()`, supporting both `bitbucket.org` and self-hosted Bitbucket instances
- Add tests for Bitbucket HTTPS and SSH URL parsing in `parseRepoUrl`

## Problem

Running `linear-release sync` from a Bitbucket-hosted repository fails with:

```
Error: Variable "$input" got invalid value null at "input.repository.provider";
Expected non-nullable type "String!" not to be null.
```

The `hostToProvider()` function only recognized GitHub and GitLab hosts, returning `null` for Bitbucket. Since `parseRepoUrl()` still successfully parses the owner/name/url from the remote, the resulting `RepoInfo` object is non-null — but with `provider: null`. This gets passed into the GraphQL mutation where `repository.provider` is a required `String!` field.

## Fix

Added a Bitbucket check to `hostToProvider()` in `src/git.ts`, matching the existing pattern for GitHub and GitLab. Bitbucket merge commit message parsing was already supported in `extractBranchNameFromMergeMessage()` — this closes the gap in provider detection.