### PR TITLE
Add RWX as a supported CI provider

### DIFF
--- a/src/ci-env.test.ts
+++ b/src/ci-env.test.ts
@@ -14,6 +14,7 @@ describe("detectCIEnvironment", () => {
     delete process.env.TF_BUILD;
     delete process.env.BUILDKITE;
     delete process.env.TEAMCITY_VERSION;
+    delete process.env.RWX;
     delete process.env.CI;
   });
 
@@ -59,6 +60,11 @@ describe("detectCIEnvironment", () => {
   it("detects TeamCity", () => {
     process.env.TEAMCITY_VERSION = "2023.05";
     expect(detectCIEnvironment()).toEqual({ name: "teamcity" });
+  });
+
+  it("detects RWX", () => {
+    process.env.RWX = "true";
+    expect(detectCIEnvironment()).toEqual({ name: "rwx" });
   });
 
   it("detects generic CI", () => {

--- a/src/ci-env.ts
+++ b/src/ci-env.ts
@@ -31,6 +31,9 @@ export function detectCIEnvironment(): CIEnvironment | null {
   if (process.env.TEAMCITY_VERSION) {
     return { name: "teamcity" };
   }
+  if (process.env.RWX === "true") {
+    return { name: "rwx" };
+  }
   if (process.env.CI === "true") {
     return { name: "ci" };
   }

--- a/src/user-agent.test.ts
+++ b/src/user-agent.test.ts
@@ -13,6 +13,7 @@ describe("buildUserAgent", () => {
     process.env = { ...originalEnv };
     // Ensure our CI environment is not detected
     delete process.env.GITHUB_ACTIONS;
+    delete process.env.RWX;
     delete process.env.CI;
   });
 
@@ -35,5 +36,11 @@ describe("buildUserAgent", () => {
     process.env.GITLAB_CI = "true";
     const userAgent = buildUserAgent();
     expect(userAgent).toBe("linear-release/1.2.3 (gitlab-ci)");
+  });
+
+  it("builds user agent for RWX", () => {
+    process.env.RWX = "true";
+    const userAgent = buildUserAgent();
+    expect(userAgent).toBe("linear-release/1.2.3 (rwx)");
   });
 });


### PR DESCRIPTION
Hey there folks - I work at [RWX](https://www.rwx.com/), a CI/CD company and Linear customer. One of the engineering teams using RWX asked about running `linear-release` on our platform, which prompted [this docs guide](https://www.rwx.com/docs/guides/linear-release) on our side; ~I'm adding an examples folder here to mirror that.~

## Summary

- ~Add `examples/rwx-continuous/` and `examples/rwx-scheduled/`~ (removed per request)
- ~Surface RWX in the `linear-release-setup` skill (platform detection, examples table, secrets reminder) and the AI-setup paragraph in the README.~ (removed per request)
- Detect `RWX=true` in `ci-env.ts` so the User-Agent reports `linear-release/x.y.z (rwx)`, matching the existing GitHub Actions / GitLab CI / CircleCI handling.