### PR TITLE
Ensure merges are properly handled for detection of issues & PRs

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -11,8 +11,8 @@ import {
   extractBranchNameFromMergeMessage,
   getCommitContext,
   getCommitContextsBetweenShas,
+  getCommitParents,
   getRepoInfo,
-  isMergeCommit,
   normalizePathspec,
   parseRepoUrl,
 } from "./git";
@@ -422,12 +422,56 @@ type TempRepoWithMerge = {
   };
 };
 
+type TempRepoWithMultipleMerges = {
+  cwd: string;
+  commits: {
+    base: string;
+    merge100: string; // Merge of feature/LIN-100 (touches frontend/)
+    merge200: string; // Merge of feature/LIN-200 (touches backend/)
+    merge300: string; // Merge of feature/LIN-300 (touches infra/ — outside includePaths)
+    headMerge: string; // Merge of release branch into main
+  };
+};
+
+type TempRepoReleaseBranch = {
+  cwd: string;
+  commits: {
+    base: string;
+    headMerge: string; // The rel-branch → main merge (HEAD)
+  };
+};
+
 function runGit(command: string, cwd: string): string {
   return execSync(`git ${command}`, {
     cwd,
     stdio: ["ignore", "pipe", "ignore"],
     encoding: "utf8",
   }).trim();
+}
+
+/**
+ * Cuts a feature branch off `baseBranch`, lands one file change, merges it
+ * back via `--no-ff` with a GitHub-style PR-merge message, then deletes the
+ * branch (mirroring CI checkout state where merged feature branches are
+ * gone). Returns the merge commit SHA.
+ */
+function mergeFeatureBranch(opts: {
+  cwd: string;
+  baseBranch: string;
+  branch: string;
+  file: string;
+  prNumber: number;
+}): string {
+  const { cwd, baseBranch, branch, file, prNumber } = opts;
+  runGit(`checkout -b ${branch} ${baseBranch}`, cwd);
+  writeFileSync(join(cwd, file), "x");
+  runGit("add .", cwd);
+  runGit(`commit -m "feature work on ${branch}"`, cwd);
+  runGit(`checkout ${baseBranch}`, cwd);
+  runGit(`merge --no-ff ${branch} -m "Merge pull request #${prNumber} from owner/${branch}"`, cwd);
+  const sha = runGit("rev-parse HEAD", cwd);
+  runGit(`branch -D ${branch}`, cwd);
+  return sha;
 }
 
 /**
@@ -519,6 +563,113 @@ function createTempRepoWithMerge(): TempRepoWithMerge {
   const mergeCommit = runGit("rev-parse HEAD", cwd);
 
   return { cwd, commits: { base, featureBranch, mergeCommit } };
+}
+
+/**
+ * Each feature branch is merged directly into main, then a release branch is
+ * cut, gets one commit, and merges back. merge300 touches infra/ — outside
+ * the includePaths used in tests, so it must not leak.
+ */
+function createTempRepoWithMultipleMerges(): TempRepoWithMultipleMerges {
+  const cwd = mkdtempSync(join(tmpdir(), "linear-release-multi-merge-"));
+  runGit("init", cwd);
+  runGit('config user.email "test@example.com"', cwd);
+  runGit('config user.name "Test User"', cwd);
+
+  mkdirSync(join(cwd, "frontend"), { recursive: true });
+  mkdirSync(join(cwd, "backend"), { recursive: true });
+  mkdirSync(join(cwd, "infra"), { recursive: true });
+  writeFileSync(join(cwd, "frontend", "seed.txt"), "seed");
+  runGit("add .", cwd);
+  runGit('commit -m "Initial"', cwd);
+  runGit("branch -M main", cwd);
+  const base = runGit("rev-parse HEAD", cwd);
+
+  const merge100 = mergeFeatureBranch({
+    cwd,
+    baseBranch: "main",
+    branch: "feature/LIN-100-add-foo",
+    file: "frontend/foo.txt",
+    prNumber: 100,
+  });
+  const merge200 = mergeFeatureBranch({
+    cwd,
+    baseBranch: "main",
+    branch: "feature/LIN-200-fix-bar",
+    file: "backend/bar.txt",
+    prNumber: 200,
+  });
+  const merge300 = mergeFeatureBranch({
+    cwd,
+    baseBranch: "main",
+    branch: "feature/LIN-300-infra",
+    file: "infra/three.txt",
+    prNumber: 300,
+  });
+
+  // rel branch needs at least one of its own commits, otherwise --no-ff is a
+  // no-op when the branches are identical.
+  runGit("checkout -b rel/2026-05-06 main", cwd);
+  writeFileSync(join(cwd, "frontend", "release-notes.txt"), "notes");
+  runGit("add .", cwd);
+  runGit('commit -m "release notes"', cwd);
+  runGit("checkout main", cwd);
+  runGit('merge --no-ff rel/2026-05-06 -m "Merge pull request #324 from owner/rel/2026-05-06"', cwd);
+  const headMerge = runGit("rev-parse HEAD", cwd);
+  runGit("branch -D rel/2026-05-06", cwd);
+
+  return { cwd, commits: { base, merge100, merge200, merge300, headMerge } };
+}
+
+/**
+ * Customer's release-branch workflow: features are merged INTO a release
+ * branch (not main), then rel is merged into main as HEAD. LIN-300 is mobile-
+ * only — outside the path filter used in tests.
+ */
+function createTempRepoReleaseBranch(): TempRepoReleaseBranch {
+  const cwd = mkdtempSync(join(tmpdir(), "linear-release-rel-branch-"));
+  runGit("init", cwd);
+  runGit('config user.email "test@example.com"', cwd);
+  runGit('config user.name "Test User"', cwd);
+
+  mkdirSync(join(cwd, "frontend-nuxt3"), { recursive: true });
+  mkdirSync(join(cwd, "backend"), { recursive: true });
+  mkdirSync(join(cwd, "mobile-android"), { recursive: true });
+  writeFileSync(join(cwd, "frontend-nuxt3", "seed.ts"), "seed");
+  runGit("add .", cwd);
+  runGit('commit -m "Initial"', cwd);
+  runGit("branch -M main", cwd);
+  const base = runGit("rev-parse HEAD", cwd);
+
+  runGit("checkout -b rel/2026-05-06 main", cwd);
+  mergeFeatureBranch({
+    cwd,
+    baseBranch: "rel/2026-05-06",
+    branch: "feature/LIN-100-foo",
+    file: "frontend-nuxt3/foo.ts",
+    prNumber: 100,
+  });
+  mergeFeatureBranch({
+    cwd,
+    baseBranch: "rel/2026-05-06",
+    branch: "feature/LIN-200-bar",
+    file: "backend/bar.ts",
+    prNumber: 200,
+  });
+  mergeFeatureBranch({
+    cwd,
+    baseBranch: "rel/2026-05-06",
+    branch: "feature/LIN-300-mobile",
+    file: "mobile-android/m.kt",
+    prNumber: 300,
+  });
+
+  runGit("checkout main", cwd);
+  runGit('merge --no-ff rel/2026-05-06 -m "Merge pull request #324 from owner/rel/2026-05-06"', cwd);
+  const headMerge = runGit("rev-parse HEAD", cwd);
+  runGit("branch -D rel/2026-05-06", cwd);
+
+  return { cwd, commits: { base, headMerge } };
 }
 
 describe("getCommitContextsBetweenShas", () => {
@@ -697,21 +848,6 @@ describe("merge commit handling", () => {
     rmSync(mergeRepo.cwd, { recursive: true, force: true });
   });
 
-  describe("isMergeCommit", () => {
-    it("should return true for a merge commit", () => {
-      expect(isMergeCommit(mergeRepo.commits.mergeCommit, mergeRepo.cwd)).toBe(true);
-    });
-
-    it("should return false for a regular commit", () => {
-      expect(isMergeCommit(mergeRepo.commits.featureBranch, mergeRepo.cwd)).toBe(false);
-      expect(isMergeCommit(mergeRepo.commits.base, mergeRepo.cwd)).toBe(false);
-    });
-
-    it("should return false for invalid SHA", () => {
-      expect(isMergeCommit("invalid-sha", mergeRepo.cwd)).toBe(false);
-    });
-  });
-
   describe("getCommitContext", () => {
     it("should return commit context for a valid SHA", () => {
       const context = getCommitContext(mergeRepo.commits.mergeCommit, mergeRepo.cwd);
@@ -730,6 +866,25 @@ describe("merge commit handling", () => {
 
     it("should return null for invalid SHA", () => {
       expect(getCommitContext("invalid-sha", mergeRepo.cwd)).toBeNull();
+    });
+  });
+
+  describe("getCommitParents", () => {
+    it("returns 2 parents for a merge commit", () => {
+      const parents = getCommitParents(mergeRepo.commits.mergeCommit, mergeRepo.cwd);
+      expect(parents).toEqual([mergeRepo.commits.base, mergeRepo.commits.featureBranch]);
+    });
+
+    it("returns 1 parent for a regular commit", () => {
+      expect(getCommitParents(mergeRepo.commits.featureBranch, mergeRepo.cwd)).toEqual([mergeRepo.commits.base]);
+    });
+
+    it("returns [] for the root commit", () => {
+      expect(getCommitParents(mergeRepo.commits.base, mergeRepo.cwd)).toEqual([]);
+    });
+
+    it("returns [] for an unknown SHA", () => {
+      expect(getCommitParents("0000000000000000000000000000000000000000", mergeRepo.cwd)).toEqual([]);
     });
   });
 
@@ -766,6 +921,100 @@ describe("merge commit handling", () => {
       // Count occurrences of merge commit
       const mergeCommitCount = result.filter((c) => c.sha === mergeRepo.commits.mergeCommit).length;
       expect(mergeCommitCount).toBe(1);
+    });
+  });
+
+  describe("getCommitContextsBetweenShas with multiple merges in range", () => {
+    let multiRepo: TempRepoWithMultipleMerges;
+
+    beforeAll(() => {
+      multiRepo = createTempRepoWithMultipleMerges();
+    });
+
+    afterAll(() => {
+      rmSync(multiRepo.cwd, { recursive: true, force: true });
+    });
+
+    it("should return in-path merges and drop out-of-path merges across a multi-merge range (LIN-69346)", () => {
+      // Without the fix, git's history simplification drops every merge commit
+      // because they're TREESAME to a parent within the paths, losing the
+      // feature/LIN-XXX branch names that are the only carrier of issue keys.
+      const result = getCommitContextsBetweenShas(multiRepo.commits.base, multiRepo.commits.headMerge, {
+        includePaths: ["frontend/**", "backend/**"],
+        cwd: multiRepo.cwd,
+      });
+
+      const shas = new Set(result.map((c) => c.sha));
+      expect(shas.has(multiRepo.commits.merge100)).toBe(true);
+      expect(shas.has(multiRepo.commits.merge200)).toBe(true);
+      // merge300 only touched infra/ — kept by the merges-only scan, then dropped
+      // by commitTouchesPaths so LIN-300 doesn't leak into a frontend release.
+      expect(shas.has(multiRepo.commits.merge300)).toBe(false);
+      expect(shas.has(multiRepo.commits.headMerge)).toBe(true);
+
+      const branchNames = result.map((c) => c.branchName).filter((b): b is string => !!b);
+      expect(branchNames).toEqual(
+        expect.arrayContaining(["feature/LIN-100-add-foo", "feature/LIN-200-fix-bar", "rel/2026-05-06"]),
+      );
+      expect(branchNames).not.toContain("feature/LIN-300-infra");
+    });
+
+    it("should return HEAD merge commit when fromSha === toSha and HEAD is a merge", () => {
+      const result = getCommitContextsBetweenShas(multiRepo.commits.headMerge, multiRepo.commits.headMerge, {
+        includePaths: ["frontend/**", "backend/**"],
+        cwd: multiRepo.cwd,
+      });
+
+      const headResult = result.find((c) => c.sha === multiRepo.commits.headMerge);
+      expect(headResult).toBeDefined();
+      expect(headResult?.branchName).toBe("rel/2026-05-06");
+    });
+
+    it("should not drift to an unrelated ancestor when fromSha === toSha and HEAD is outside includePaths", () => {
+      // The legacy `git log -1 <sha> -- <paths>` walked back from <sha> when it
+      // didn't match, returning an unrelated ancestor. We use --no-walk semantics
+      // instead: match the exact commit or return nothing.
+      const result = getCommitContextsBetweenShas(multiRepo.commits.merge300, multiRepo.commits.merge300, {
+        includePaths: ["frontend/**"],
+        cwd: multiRepo.cwd,
+      });
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getCommitContextsBetweenShas with release-branch workflow (LIN-69346)", () => {
+    // Mirrors the customer's first-sync scenario exactly: features are merged
+    // INTO a release branch (not main), then rel is merged into main as HEAD.
+    // With no prior release SHA on the pipeline, the CLI uses HEAD^1 as the
+    // implicit boundary — without that boundary, scanning HEAD alone would
+    // miss every issue key.
+    let relRepo: TempRepoReleaseBranch;
+
+    beforeAll(() => {
+      relRepo = createTempRepoReleaseBranch();
+    });
+
+    afterAll(() => {
+      rmSync(relRepo.cwd, { recursive: true, force: true });
+    });
+
+    it("should surface feature merges from inside the rel branch when scanning HEAD^1..HEAD", () => {
+      const parents = getCommitParents(relRepo.commits.headMerge, relRepo.cwd);
+      expect(parents.length).toBeGreaterThanOrEqual(1);
+      const parent = parents[0]!;
+
+      const result = getCommitContextsBetweenShas(parent, relRepo.commits.headMerge, {
+        includePaths: ["frontend-nuxt3/**", "backend/**"],
+        cwd: relRepo.cwd,
+      });
+
+      const branchNames = result.map((c) => c.branchName).filter((b): b is string => !!b);
+      expect(branchNames).toEqual(
+        expect.arrayContaining(["feature/LIN-100-foo", "feature/LIN-200-bar", "rel/2026-05-06"]),
+      );
+      // LIN-300 is mobile-only — outside the path filter — must not leak.
+      expect(branchNames).not.toContain("feature/LIN-300-mobile");
     });
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -15,6 +15,7 @@ import {
   getRepoInfo,
   normalizePathspec,
   parseRepoUrl,
+  resolveFirstSyncBoundary,
 } from "./git";
 
 describe("normalizePathspec", () => {
@@ -450,6 +451,29 @@ function runGit(command: string, cwd: string): string {
 }
 
 /**
+ * Initializes a tmpdir repo, configures user, creates the listed directories,
+ * lands a seed commit, and renames the branch to `main`. Returns the cwd and
+ * base SHA.
+ */
+function initTempRepo(opts: { prefix: string; dirs: string[]; seedFile: { path: string; content: string } }): {
+  cwd: string;
+  base: string;
+} {
+  const cwd = mkdtempSync(join(tmpdir(), opts.prefix));
+  runGit("init", cwd);
+  runGit('config user.email "test@example.com"', cwd);
+  runGit('config user.name "Test User"', cwd);
+  for (const dir of opts.dirs) {
+    mkdirSync(join(cwd, dir), { recursive: true });
+  }
+  writeFileSync(join(cwd, opts.seedFile.path), opts.seedFile.content);
+  runGit("add .", cwd);
+  runGit('commit -m "Initial"', cwd);
+  runGit("branch -M main", cwd);
+  return { cwd, base: runGit("rev-parse HEAD", cwd) };
+}
+
+/**
  * Cuts `branch` off `baseBranch`, lands one file change, merges back via
  * `--no-ff` with a GitHub-style PR-merge message, then deletes `branch` to
  * mirror a CI checkout (merged feature branches gone). Returns the merge SHA.
@@ -569,19 +593,11 @@ function createTempRepoWithMerge(): TempRepoWithMerge {
  * commit merged back as HEAD. `merge300` touches `infra/` only.
  */
 function createTempRepoWithMultipleMerges(): TempRepoWithMultipleMerges {
-  const cwd = mkdtempSync(join(tmpdir(), "linear-release-multi-merge-"));
-  runGit("init", cwd);
-  runGit('config user.email "test@example.com"', cwd);
-  runGit('config user.name "Test User"', cwd);
-
-  mkdirSync(join(cwd, "frontend"), { recursive: true });
-  mkdirSync(join(cwd, "backend"), { recursive: true });
-  mkdirSync(join(cwd, "infra"), { recursive: true });
-  writeFileSync(join(cwd, "frontend", "seed.txt"), "seed");
-  runGit("add .", cwd);
-  runGit('commit -m "Initial"', cwd);
-  runGit("branch -M main", cwd);
-  const base = runGit("rev-parse HEAD", cwd);
+  const { cwd, base } = initTempRepo({
+    prefix: "linear-release-multi-merge-",
+    dirs: ["frontend", "backend", "infra"],
+    seedFile: { path: "frontend/seed.txt", content: "seed" },
+  });
 
   const merge100 = mergeFeatureBranch({
     cwd,
@@ -625,19 +641,11 @@ function createTempRepoWithMultipleMerges(): TempRepoWithMultipleMerges {
  * only.
  */
 function createTempRepoReleaseBranch(): TempRepoReleaseBranch {
-  const cwd = mkdtempSync(join(tmpdir(), "linear-release-rel-branch-"));
-  runGit("init", cwd);
-  runGit('config user.email "test@example.com"', cwd);
-  runGit('config user.name "Test User"', cwd);
-
-  mkdirSync(join(cwd, "frontend-nuxt3"), { recursive: true });
-  mkdirSync(join(cwd, "backend"), { recursive: true });
-  mkdirSync(join(cwd, "mobile-android"), { recursive: true });
-  writeFileSync(join(cwd, "frontend-nuxt3", "seed.ts"), "seed");
-  runGit("add .", cwd);
-  runGit('commit -m "Initial"', cwd);
-  runGit("branch -M main", cwd);
-  const base = runGit("rev-parse HEAD", cwd);
+  const { cwd, base } = initTempRepo({
+    prefix: "linear-release-rel-branch-",
+    dirs: ["frontend-nuxt3", "backend", "mobile-android"],
+    seedFile: { path: "frontend-nuxt3/seed.ts", content: "seed" },
+  });
 
   runGit("checkout -b rel/2026-05-06 main", cwd);
   mergeFeatureBranch({
@@ -887,6 +895,22 @@ describe("merge commit handling", () => {
     });
   });
 
+  describe("resolveFirstSyncBoundary", () => {
+    it("expands to HEAD^1 when HEAD is a merge commit", () => {
+      expect(resolveFirstSyncBoundary(mergeRepo.commits.mergeCommit, mergeRepo.cwd)).toBe(mergeRepo.commits.base);
+    });
+
+    it("returns the commit itself when HEAD is a regular commit", () => {
+      expect(resolveFirstSyncBoundary(mergeRepo.commits.featureBranch, mergeRepo.cwd)).toBe(
+        mergeRepo.commits.featureBranch,
+      );
+    });
+
+    it("returns the commit itself when HEAD is the root commit", () => {
+      expect(resolveFirstSyncBoundary(mergeRepo.commits.base, mergeRepo.cwd)).toBe(mergeRepo.commits.base);
+    });
+  });
+
   describe("getCommitContextsBetweenShas with merge commits", () => {
     it("should include merge commit when path filtering would exclude it", () => {
       // The merge node itself adds no file changes, so default simplification
@@ -997,12 +1021,14 @@ describe("merge commit handling", () => {
       rmSync(relRepo.cwd, { recursive: true, force: true });
     });
 
-    it("should surface feature merges from inside the rel branch when scanning HEAD^1..HEAD", () => {
-      const parents = getCommitParents(relRepo.commits.headMerge, relRepo.cwd);
-      expect(parents.length).toBeGreaterThanOrEqual(1);
-      const parent = parents[0]!;
+    it("should surface feature merges from inside the rel branch when scanning the resolved first-sync boundary", () => {
+      // Mirrors the customer's first-sync flow: resolveFirstSyncBoundary picks
+      // HEAD^1 because HEAD is a merge, then getCommitContextsBetweenShas runs
+      // over that range.
+      const boundary = resolveFirstSyncBoundary(relRepo.commits.headMerge, relRepo.cwd);
+      expect(boundary).not.toBe(relRepo.commits.headMerge);
 
-      const result = getCommitContextsBetweenShas(parent, relRepo.commits.headMerge, {
+      const result = getCommitContextsBetweenShas(boundary, relRepo.commits.headMerge, {
         includePaths: ["frontend-nuxt3/**", "backend/**"],
         cwd: relRepo.cwd,
       });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -450,10 +450,9 @@ function runGit(command: string, cwd: string): string {
 }
 
 /**
- * Cuts a feature branch off `baseBranch`, lands one file change, merges it
- * back via `--no-ff` with a GitHub-style PR-merge message, then deletes the
- * branch (mirroring CI checkout state where merged feature branches are
- * gone). Returns the merge commit SHA.
+ * Cuts `branch` off `baseBranch`, lands one file change, merges back via
+ * `--no-ff` with a GitHub-style PR-merge message, then deletes `branch` to
+ * mirror a CI checkout (merged feature branches gone). Returns the merge SHA.
  */
 function mergeFeatureBranch(opts: {
   cwd: string;
@@ -566,9 +565,8 @@ function createTempRepoWithMerge(): TempRepoWithMerge {
 }
 
 /**
- * Each feature branch is merged directly into main, then a release branch is
- * cut, gets one commit, and merges back. merge300 touches infra/ — outside
- * the includePaths used in tests, so it must not leak.
+ * Three feature branches merged into main, then a release branch with one
+ * commit merged back as HEAD. `merge300` touches `infra/` only.
  */
 function createTempRepoWithMultipleMerges(): TempRepoWithMultipleMerges {
   const cwd = mkdtempSync(join(tmpdir(), "linear-release-multi-merge-"));
@@ -622,9 +620,9 @@ function createTempRepoWithMultipleMerges(): TempRepoWithMultipleMerges {
 }
 
 /**
- * Customer's release-branch workflow: features are merged INTO a release
- * branch (not main), then rel is merged into main as HEAD. LIN-300 is mobile-
- * only — outside the path filter used in tests.
+ * Release-branch workflow: features merged INTO `rel/2026-05-06`, then rel
+ * merged into main as HEAD. `feature/LIN-300-mobile` touches `mobile-android/`
+ * only.
  */
 function createTempRepoReleaseBranch(): TempRepoReleaseBranch {
   const cwd = mkdtempSync(join(tmpdir(), "linear-release-rel-branch-"));
@@ -803,8 +801,9 @@ describe("getCommitContextsBetweenShas", () => {
     try {
       process.chdir(join(repo.cwd, "src"));
 
-      // Without the fix, this would fail because git would look for "src/**" relative to
-      // the subdirectory (i.e., src/src/**) which doesn't exist
+      // The `:(top,...)` magic prefix in buildPathspecArgs anchors the glob
+      // at the repo root regardless of cwd; without it git would resolve
+      // "src/**" against the subdirectory (i.e., src/src/**).
       const result = getCommitContextsBetweenShas(
         repo.commits.first,
         repo.commits.third,
@@ -890,15 +889,15 @@ describe("merge commit handling", () => {
 
   describe("getCommitContextsBetweenShas with merge commits", () => {
     it("should include merge commit when path filtering would exclude it", () => {
-      // Without the fix, path filtering for "src/**" would only return the feature branch commit
-      // because merge commits don't have direct file changes.
-      // With the fix, the merge commit should be included for metadata extraction.
+      // The merge node itself adds no file changes, so default simplification
+      // would drop it; `--full-history` keeps it for metadata (PR number,
+      // branch name) extraction.
       const result = getCommitContextsBetweenShas(mergeRepo.commits.base, mergeRepo.commits.mergeCommit, {
         includePaths: ["src/**"],
         cwd: mergeRepo.cwd,
       });
 
-      // Should include both: the merge commit (for metadata) and the feature commit (for file changes)
+      // Both the merge (for metadata) and the feature commit (for file changes).
       expect(result.length).toBeGreaterThanOrEqual(2);
 
       // The merge commit should be first (unshifted)
@@ -935,10 +934,10 @@ describe("merge commit handling", () => {
       rmSync(multiRepo.cwd, { recursive: true, force: true });
     });
 
-    it("should return in-path merges and drop out-of-path merges across a multi-merge range (LIN-69346)", () => {
-      // Without the fix, git's history simplification drops every merge commit
-      // because they're TREESAME to a parent within the paths, losing the
-      // feature/LIN-XXX branch names that are the only carrier of issue keys.
+    it("should return in-path merges and drop out-of-path merges across a multi-merge range", () => {
+      // `--full-history` keeps merges whose contribution arrived via a non-
+      // first parent. Their tree equals one parent's, so default simplification
+      // would drop them — and with them the issue keys in their branch names.
       const result = getCommitContextsBetweenShas(multiRepo.commits.base, multiRepo.commits.headMerge, {
         includePaths: ["frontend/**", "backend/**"],
         cwd: multiRepo.cwd,
@@ -971,9 +970,9 @@ describe("merge commit handling", () => {
     });
 
     it("should not drift to an unrelated ancestor when fromSha === toSha and HEAD is outside includePaths", () => {
-      // The legacy `git log -1 <sha> -- <paths>` walked back from <sha> when it
-      // didn't match, returning an unrelated ancestor. We use --no-walk semantics
-      // instead: match the exact commit or return nothing.
+      // `git log -1 <sha> -- <paths>` walks back from <sha> until something
+      // matches the pathspec — `--no-walk` makes it return only <sha>, or
+      // nothing if <sha> doesn't match.
       const result = getCommitContextsBetweenShas(multiRepo.commits.merge300, multiRepo.commits.merge300, {
         includePaths: ["frontend/**"],
         cwd: multiRepo.cwd,
@@ -983,12 +982,11 @@ describe("merge commit handling", () => {
     });
   });
 
-  describe("getCommitContextsBetweenShas with release-branch workflow (LIN-69346)", () => {
-    // Mirrors the customer's first-sync scenario exactly: features are merged
-    // INTO a release branch (not main), then rel is merged into main as HEAD.
-    // With no prior release SHA on the pipeline, the CLI uses HEAD^1 as the
-    // implicit boundary — without that boundary, scanning HEAD alone would
-    // miss every issue key.
+  describe("getCommitContextsBetweenShas with release-branch workflow", () => {
+    // First sync (no prior release SHA) on a merge HEAD: scanning HEAD alone
+    // finds no keys because HEAD's branch is the rel branch, not any feature.
+    // Caller passes HEAD^1 as the boundary so the rel branch's contents are in
+    // range.
     let relRepo: TempRepoReleaseBranch;
 
     beforeAll(() => {

--- a/src/git.ts
+++ b/src/git.ts
@@ -123,6 +123,19 @@ export function extractBranchName(rawDecorations: string | undefined): string | 
 }
 
 /**
+ * Implicit scan boundary for a first-time release sync (no prior release SHA).
+ * Expands a merge HEAD to its first parent so the merged-in branch's commits
+ * are in range — issue keys live there, not on the merge node itself.
+ */
+export function resolveFirstSyncBoundary(currentSha: string, cwd: string = process.cwd()): string {
+  const parents = getCommitParents(currentSha, cwd);
+  if (parents.length > 1 && parents[0]) {
+    return parents[0];
+  }
+  return currentSha;
+}
+
+/**
  * Returns `sha`'s parent SHAs in order. Empty array if the commit has no
  * reachable parents — root commit, unknown SHA, or shallow clone where the
  * parents aren't in the local repo. Merges have 2+ entries.

--- a/src/git.ts
+++ b/src/git.ts
@@ -122,6 +122,25 @@ export function extractBranchName(rawDecorations: string | undefined): string | 
   return preferred.sort((a, b) => b.length - a.length)[0]!;
 }
 
+/**
+ * Returns `sha`'s parent SHAs (in order), or an empty array if the commit has
+ * no reachable parents — root commit, unknown SHA, or shallow clone where the
+ * parents aren't in the local repo. A merge commit has 2+ parents; a regular
+ * commit has 1; the root commit has 0.
+ */
+export function getCommitParents(sha: string, cwd: string = process.cwd()): string[] {
+  try {
+    const out = execSync(`git log -1 --format=%P ${sha}`, {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    return out ? out.split(" ").filter((p) => /^[0-9a-f]{40}$/i.test(p)) : [];
+  } catch {
+    return [];
+  }
+}
+
 export function commitExists(sha: string, cwd: string = process.cwd()): boolean {
   try {
     execSync(`git cat-file -e ${sha}^{commit}`, {
@@ -135,32 +154,6 @@ export function commitExists(sha: string, cwd: string = process.cwd()): boolean 
 }
 
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
-
-/**
- * Returns true if the commit has more than one parent (i.e., is a merge commit).
- */
-export function isMergeCommit(sha: string, cwd: string = process.cwd()): boolean {
-  if (!SHA_PATTERN.test(sha)) {
-    warn(`isMergeCommit: Invalid SHA format "${sha}"`);
-    return false;
-  }
-
-  try {
-    // %P returns space-separated parent hashes
-    // Regular commits have 1 parent (no space), merge commits have 2+ (contains space)
-    const parentHashes = execSync(`git log -1 --format=%P ${sha}`, {
-      cwd,
-      stdio: ["ignore", "pipe", "ignore"],
-      encoding: "utf8",
-    }).trim();
-
-    return parentHashes.includes(" ");
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    warn(`isMergeCommit: Failed to check ${sha}: ${message}`);
-    return false;
-  }
-}
 
 /**
  * Extracts the branch name from a merge commit message.
@@ -211,21 +204,8 @@ export function getCommitContext(sha: string, cwd: string = process.cwd()): Comm
     warn(`getCommitContext: Invalid SHA format "${sha}"`);
     return null;
   }
-
   try {
-    const output = execSync(`git log -1 --format=%H%x1f%B%x1f%D%x1e ${sha}`, {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-      encoding: "utf8",
-    });
-
-    const chunk = output.split("\x1e")[0];
-    if (!chunk || chunk.trim().length === 0) {
-      warn(`getCommitContext: Empty output for ${sha}`);
-      return null;
-    }
-
-    return parseCommitChunk(chunk);
+    return runLog(`-1 ${sha}`, cwd)[0] ?? null;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     warn(`getCommitContext: Failed to get context for ${sha}: ${message}`);
@@ -278,8 +258,33 @@ export function ensureCommitAvailable(sha: string, cwd: string = process.cwd()):
   );
 }
 
+function runLog(rangeArgs: string, cwd: string): CommitContext[] {
+  const output = execSync(`git log --format=%H%x1f%B%x1f%D%x1e ${rangeArgs}`, {
+    cwd,
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+  return output
+    .split("\x1e")
+    .filter((chunk) => chunk.trim().length > 0)
+    .map(parseCommitChunk);
+}
+
 /**
  * Returns commits between two SHAs, optionally filtered by file paths.
+ *
+ * When `includePaths` is set we pass `--full-history` to disable git's
+ * default history simplification, which would otherwise drop merge commits
+ * that are TREESAME to a parent within the paths — i.e. virtually every
+ * GitHub merge, since the merge itself adds no new file changes. Dropping
+ * them loses the issue keys encoded in `feature/LIN-XXX-...` branch names.
+ * `--full-history` keeps every commit (merge or not) that contributed to
+ * the path's history, including merges whose contribution arrived via a
+ * non-first parent. See LIN-69346.
+ *
+ * For `fromSha === toSha` (first-time sync where there's no prior release),
+ * we add `--no-walk` so git evaluates the requested commit directly instead
+ * of walking back to the first ancestor matching the pathspec.
  *
  * @param fromSha - Starting commit SHA (exclusive)
  * @param toSha - Ending commit SHA (inclusive)
@@ -302,37 +307,14 @@ export function getCommitContextsBetweenShas(
     return [];
   }
 
-  const pathspecArgs = buildPathspecArgs(includePaths);
-
-  // If fromSha and toSha are the same, get that single commit only
-  const logCommand =
-    fromSha === toSha
-      ? `git log -1 --format=%H%x1f%B%x1f%D%x1e ${toSha} ${pathspecArgs}`
-      : `git log --format=%H%x1f%B%x1f%D%x1e ${fromSha}..${toSha} ${pathspecArgs}`;
-
-  const output = execSync(logCommand, {
-    cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    encoding: "utf8",
-  });
-
-  const commits = output
-    .split("\x1e")
-    .filter((chunk) => chunk.trim().length > 0)
-    .map(parseCommitChunk);
-
-  /**
-   * Path filtering can exclude a merge commit at toSha. This is because merge commits have no direct file changes.
-   * We still want to include it for metadata extraction, like PR numbers and branch names.
-   */
-  const toShaWasExcluded = includePaths?.length && !commits.some((c) => c.sha === toSha);
-
-  if (toShaWasExcluded && isMergeCommit(toSha, cwd)) {
-    const mergeCommit = getCommitContext(toSha, cwd);
-    if (mergeCommit) {
-      commits.unshift(mergeCommit);
-    }
-  }
+  const args = [
+    includePaths?.length ? "--full-history" : "",
+    fromSha === toSha ? `--no-walk ${toSha}` : `${fromSha}..${toSha}`,
+    buildPathspecArgs(includePaths),
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const commits = runLog(args, cwd);
 
   if (commits.length === 0) {
     verbose(

--- a/src/git.ts
+++ b/src/git.ts
@@ -123,10 +123,9 @@ export function extractBranchName(rawDecorations: string | undefined): string | 
 }
 
 /**
- * Returns `sha`'s parent SHAs (in order), or an empty array if the commit has
- * no reachable parents — root commit, unknown SHA, or shallow clone where the
- * parents aren't in the local repo. A merge commit has 2+ parents; a regular
- * commit has 1; the root commit has 0.
+ * Returns `sha`'s parent SHAs in order. Empty array if the commit has no
+ * reachable parents — root commit, unknown SHA, or shallow clone where the
+ * parents aren't in the local repo. Merges have 2+ entries.
  */
 export function getCommitParents(sha: string, cwd: string = process.cwd()): string[] {
   try {
@@ -273,18 +272,16 @@ function runLog(rangeArgs: string, cwd: string): CommitContext[] {
 /**
  * Returns commits between two SHAs, optionally filtered by file paths.
  *
- * When `includePaths` is set we pass `--full-history` to disable git's
- * default history simplification, which would otherwise drop merge commits
- * that are TREESAME to a parent within the paths — i.e. virtually every
- * GitHub merge, since the merge itself adds no new file changes. Dropping
- * them loses the issue keys encoded in `feature/LIN-XXX-...` branch names.
- * `--full-history` keeps every commit (merge or not) that contributed to
- * the path's history, including merges whose contribution arrived via a
- * non-first parent. See LIN-69346.
+ * `--full-history` (only when `includePaths` is set): a non-evil merge's
+ * tree equals one of its parents' trees, so under a pathspec it's TREESAME
+ * and git's default simplification drops it. That's true of every provider's
+ * merge commit (GitHub, GitLab MR, Bitbucket PR, plain `git merge --no-ff`)
+ * and would lose the issue keys encoded in their feature-branch names.
  *
- * For `fromSha === toSha` (first-time sync where there's no prior release),
- * we add `--no-walk` so git evaluates the requested commit directly instead
- * of walking back to the first ancestor matching the pathspec.
+ * `--no-walk` (only when `fromSha === toSha`): without it, `git log -1 <sha>
+ * -- <paths>` walks back from `<sha>` to the first ancestor matching the
+ * pathspec — silently returning an unrelated commit when `<sha>` itself
+ * doesn't match.
  *
  * @param fromSha - Starting commit SHA (exclusive)
  * @param toSha - Ending commit SHA (inclusive)

--- a/src/index.ts
+++ b/src/index.ts
@@ -350,10 +350,9 @@ async function getLatestSha(): Promise<string> {
     throw new Error("Could not get current commit");
   }
 
-  // First sync, merge HEAD: expand to HEAD^1 so we scan everything brought in
-  // via the merge — otherwise the LIN keys live on HEAD^2's branch and we'd
-  // miss them all. For non-merge HEAD (squash, direct commit) the LIN key is
-  // on HEAD itself, so the conservative HEAD-only scan is correct.
+  // Merge HEAD has no issue keys on itself — they live on HEAD^2's branch.
+  // Scanning HEAD^1..HEAD picks them up. Non-merge HEAD carries its own key,
+  // so HEAD-only stays correct.
   const parents = getCommitParents(currentSha);
   if (parents.length > 1 && parents[0]) {
     verbose(`First sync on merge HEAD: using HEAD^1 (${parents[0]}) as the scan boundary`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,9 @@ import {
   assertGitAvailable,
   ensureCommitAvailable,
   getCommitContextsBetweenShas,
-  getCommitParents,
   getCurrentGitInfo,
   getRepoInfo,
+  resolveFirstSyncBoundary,
 } from "./git";
 import { scanCommits } from "./scan";
 import {
@@ -350,16 +350,15 @@ async function getLatestSha(): Promise<string> {
     throw new Error("Could not get current commit");
   }
 
-  // Merge HEAD has no issue keys on itself — they live on HEAD^2's branch.
-  // Scanning HEAD^1..HEAD picks them up. Non-merge HEAD carries its own key,
-  // so HEAD-only stays correct.
-  const parents = getCommitParents(currentSha);
-  if (parents.length > 1 && parents[0]) {
-    verbose(`First sync on merge HEAD: using HEAD^1 (${parents[0]}) as the scan boundary`);
-    return parents[0];
+  // For a merge HEAD the issue keys live on HEAD^2's branch, not on HEAD
+  // itself, so HEAD-only would miss them. Non-merge HEAD carries its own key.
+  const boundary = resolveFirstSyncBoundary(currentSha);
+  if (boundary !== currentSha) {
+    verbose(`First sync on merge HEAD: using HEAD^1 (${boundary}) as the scan boundary`);
+  } else {
+    verbose("First sync: only inspecting current commit");
   }
-  verbose("First sync: only inspecting current commit");
-  return currentSha;
+  return boundary;
 }
 
 async function getPipelineSettings(): Promise<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   assertGitAvailable,
   ensureCommitAvailable,
   getCommitContextsBetweenShas,
+  getCommitParents,
   getCurrentGitInfo,
   getRepoInfo,
 } from "./git";
@@ -339,16 +340,26 @@ async function getLatestSha(): Promise<string> {
     return latestSha;
   }
 
-  // If we can't find a release or the latest release has no commit SHA, we will only inspect the current commit
   if (!latestRelease) {
-    verbose("Could not find latest release, assuming it's the first release, will only inspect the current commit");
+    verbose("Could not find latest release, assuming it's the first release");
   } else if (!latestRelease.commitSha) {
-    verbose("Latest release has no commit SHA, will only inspect the current commit");
+    verbose("Latest release has no commit SHA");
   }
   const currentSha = await getCurrentGitInfo().commit;
   if (!currentSha) {
     throw new Error("Could not get current commit");
   }
+
+  // First sync, merge HEAD: expand to HEAD^1 so we scan everything brought in
+  // via the merge — otherwise the LIN keys live on HEAD^2's branch and we'd
+  // miss them all. For non-merge HEAD (squash, direct commit) the LIN key is
+  // on HEAD itself, so the conservative HEAD-only scan is correct.
+  const parents = getCommitParents(currentSha);
+  if (parents.length > 1 && parents[0]) {
+    verbose(`First sync on merge HEAD: using HEAD^1 (${parents[0]}) as the scan boundary`);
+    return parents[0];
+  }
+  verbose("First sync: only inspecting current commit");
   return currentSha;
 }
 


### PR DESCRIPTION
**Fix releases missing all issue keys on first sync with merge-commit HEAD**

When a release pipeline has no prior release and HEAD is a merge commit (e.g. release-branch workflow merging into main), the action scans only HEAD itself — but the LIN keys live on `HEAD^2`'s incoming history, so nothing gets extracted. 

Two layered fixes:

1. **`src/index.ts:getLatestSha`** — when there's no prior release SHA *and* HEAD is a merge, use `HEAD^1` as the scan boundary instead of falling back to `currentSha`. Range becomes `HEAD^1..HEAD`, which captures everything brought in via the merge. Non-merge HEAD (squash, direct commit) keeps the conservative HEAD-only behavior.

2. **`src/git.ts:getCommitContextsBetweenShas`** — pass `--full-history` when `includePaths` is set, so git stops dropping merge commits as TREESAME within the filtered paths. Also `--no-walk` for `from === to` to prevent drift to unrelated ancestors.
