### PR TITLE
Extract added issues from the body of a revert commit

### DIFF
--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -445,23 +445,17 @@ describe("revert branch handling", () => {
   });
 
   it("extracts magic-word references from a revert commit body as added (issue closed by the revert)", () => {
-    // A revert PR whose body says `Fixes LIN-N` is closing that issue *by*
-    // reverting. Previously these references were dropped entirely, so the
-    // deployed-status transition never fired.
     const message = `Revert "Migration ActionMenu to StyleX" (#73629)
 
-Fixes LIN-69675`;
+Fixes ENG-123`;
     const result = extractLinearIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
-    expect(ids(result)).toEqual(["LIN-69675"]);
+    expect(ids(result)).toEqual(["ENG-123"]);
   });
 
-  it("revert body with a stray quote does not leak the body into the reverted bucket", () => {
-    // The previous regex was greedy + dotall, so any `"` later in the body
-    // would extend the captured "inner subject" across the entire message and
-    // pull body magic-word references into the reverted bucket.
+  it("stray quote in revert body does not leak the body into the reverted bucket", () => {
     const message = `Revert "Original title" (#73629)
 
-Fixes LIN-69675 said "ship it"`;
+Fixes ENG-123 said "ship it"`;
     const result = extractRevertedIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
     expect(ids(result)).toEqual([]);
   });
@@ -687,9 +681,6 @@ Closes LIN-200`;
   });
 
   it("strips squash blocks from a revert commit body before scanning for added references", () => {
-    // A real revert: subject on one line, body may contain a nested squash
-    // dump from earlier branch history. References inside the dump describe
-    // already-shipped commits — they must not be re-attributed to the revert.
     const message = `Revert "Some PR"
 
 Squashed commit of the following:

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -444,6 +444,36 @@ describe("revert branch handling", () => {
     expect(ids(result)).toEqual(["ENG-100"]);
   });
 
+  it("extracts magic-word references from a revert commit body as added (issue closed by the revert)", () => {
+    // A revert PR whose body says `Fixes LIN-N` is closing that issue *by*
+    // reverting. Previously these references were dropped entirely, so the
+    // deployed-status transition never fired.
+    const message = `Revert "Migration ActionMenu to StyleX" (#73629)
+
+Fixes LIN-69675`;
+    const result = extractLinearIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
+    expect(ids(result)).toEqual(["LIN-69675"]);
+  });
+
+  it("revert body with a stray quote does not leak the body into the reverted bucket", () => {
+    // The previous regex was greedy + dotall, so any `"` later in the body
+    // would extend the captured "inner subject" across the entire message and
+    // pull body magic-word references into the reverted bucket.
+    const message = `Revert "Original title" (#73629)
+
+Fixes LIN-69675 said "ship it"`;
+    const result = extractRevertedIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
+    expect(ids(result)).toEqual([]);
+  });
+
+  it("revert with magic word in both inner subject and body splits added vs reverted", () => {
+    const message = `Revert "Fixes ENG-100"
+
+Fixes LIN-50`;
+    expect(ids(extractLinearIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["LIN-50"]);
+    expect(ids(extractRevertedIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["ENG-100"]);
+  });
+
   it("allows extraction from revert-of-revert branch (even depth)", () => {
     const result = extractLinearIssueIdentifiersForCommit({
       sha: "abc",
@@ -656,11 +686,15 @@ Closes LIN-200`;
     expect(ids(extractLinearIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["LIN-200"]);
   });
 
-  it("does not strip squash blocks from revert add-extraction (revert path is already blocked)", () => {
-    // A revert message that wraps a squash dump shouldn't add anything.
-    const message = `Revert "Squashed commit of the following:
+  it("strips squash blocks from a revert commit body before scanning for added references", () => {
+    // A real revert: subject on one line, body may contain a nested squash
+    // dump from earlier branch history. References inside the dump describe
+    // already-shipped commits — they must not be re-attributed to the revert.
+    const message = `Revert "Some PR"
 
-    Fixes LIN-50"`;
+Squashed commit of the following:
+
+    Fixes LIN-50`;
     expect(ids(extractLinearIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual([]);
   });
 });

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -448,7 +448,25 @@ describe("revert branch handling", () => {
     const message = `Revert "Migration ActionMenu to StyleX" (#73629)
 
 Fixes ENG-123`;
-    const result = extractLinearIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message,
+    });
+    expect(ids(result)).toEqual(["ENG-123"]);
+  });
+
+  it("scans the revert body even when branch is the GitHub auto-revert form", () => {
+    // GitHub's "Revert" button creates `revert-<N>-<original-branch>`. The
+    // branch contribution is suppressed (inner names the reverted work), but
+    // the revert author's body note must still flow to added.
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: "revert-456-axel/eng-100-original-feature",
+      message: `Revert "Original feature" (#456)
+
+Fixes ENG-123`,
+    });
     expect(ids(result)).toEqual(["ENG-123"]);
   });
 
@@ -456,15 +474,19 @@ Fixes ENG-123`;
     const message = `Revert "Original title" (#73629)
 
 Fixes ENG-123 said "ship it"`;
-    const result = extractRevertedIssueIdentifiersForCommit({ sha: "abc", branchName: null, message });
+    const result = extractRevertedIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message,
+    });
     expect(ids(result)).toEqual([]);
   });
 
   it("revert with magic word in both inner subject and body splits added vs reverted", () => {
     const message = `Revert "Fixes ENG-100"
 
-Fixes LIN-50`;
-    expect(ids(extractLinearIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["LIN-50"]);
+Fixes ENG-123`;
+    expect(ids(extractLinearIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["ENG-123"]);
     expect(ids(extractRevertedIssueIdentifiersForCommit({ sha: "abc", message }))).toEqual(["ENG-100"]);
   });
 

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -195,8 +195,7 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
     return [];
   }
 
-  // Odd depth = the commit is undoing previous work (a revert), so we must not
-  // count the reverted subject's identifiers as "added". Even depth = revert-of-revert (re-add).
+  // Odd depth = revert (skip); even depth = non-revert or revert-of-revert (re-add).
   const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(commit.branchName ?? "");
   if (branchDepth % 2 === 1) {
     verbose(`Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`);
@@ -214,15 +213,10 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
     }
   }
 
-  // For odd messageDepth (a revert), the inner subject describes the original
-  // commit being undone — its identifiers are reverted, not added. But the
-  // revert author's own notes live in the body (and any trailing content on
-  // the subject line), so we still scan those for magic-word references like
-  // `Fixes LIN-N` that describe what the revert itself closes.
-  // For even depth (non-revert, or revert-of-revert), the full message is fair
-  // game — same as the original behavior.
-  // Strip any squashed sub-commit dump first so references that came from
-  // already-merged branch history don't get re-attributed to this commit.
+  // In a revert, the inner subject's identifiers are reverted, not added — but
+  // the revert author's body (e.g. `Fixes LIN-N`) describes what the revert
+  // itself closes, so scan that. Strip squash dumps first to avoid attributing
+  // already-shipped references to this commit.
   const scanTarget = messageDepth % 2 === 1 ? afterTitle : (commit.message ?? "");
   const message = stripSquashBlock(scanTarget);
   if (message.length > 0) {
@@ -344,16 +338,11 @@ export function getRevertBranchDepth(branchName: string | null | undefined): num
 }
 
 /**
- * Unwrap `Revert "..."` layers found on the subject line only.
- *
- * The subject line is the canonical place where `git revert` writes the wrapper;
- * scanning the whole message would let a stray `"` in the body close the regex
- * far past the real subject, swallowing magic-word references the revert author
- * added (e.g. `Fixes LIN-N` describing what the revert itself fixes) into the
- * "reverted" pile. `afterTitle` collects everything that is NOT part of the
- * unwrapped subject — both any trailing content on the subject line (such as
- * `(#N)`) and the entire body — so callers can scan it for the revert author's
- * own references.
+ * Unwrap `Revert "..."` layers on the subject line only. Scanning the whole
+ * message would let a stray `"` in the body extend the capture past the real
+ * subject. `afterTitle` is everything outside the unwrapped subject (trailing
+ * content on the subject line plus the body), so callers can scan it for the
+ * revert author's own references.
  */
 function parseRevertMessage(message: string): { depth: number; inner: string; afterTitle: string } {
   const newlineIdx = message.search(/\r?\n/);

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -196,17 +196,13 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
   }
 
   // Odd depth = the commit is undoing previous work (a revert), so we must not
-  // count its identifiers as "added". Even depth = revert-of-revert (re-add).
+  // count the reverted subject's identifiers as "added". Even depth = revert-of-revert (re-add).
   const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(commit.branchName ?? "");
   if (branchDepth % 2 === 1) {
     verbose(`Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`);
     return [];
   }
-  const { depth: messageDepth } = parseRevertMessage(commit.message ?? "");
-  if (messageDepth % 2 === 1) {
-    verbose(`Skipping revert message (depth ${messageDepth}) for commit ${commit.sha}`);
-    return [];
-  }
+  const { depth: messageDepth, afterTitle } = parseRevertMessage(commit.message ?? "");
 
   const found = new Map<string, ExtractedIdentifier>();
 
@@ -218,10 +214,17 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
     }
   }
 
-  // Commit message: only extract when preceded by a magic word.
+  // For odd messageDepth (a revert), the inner subject describes the original
+  // commit being undone — its identifiers are reverted, not added. But the
+  // revert author's own notes live in the body (and any trailing content on
+  // the subject line), so we still scan those for magic-word references like
+  // `Fixes LIN-N` that describe what the revert itself closes.
+  // For even depth (non-revert, or revert-of-revert), the full message is fair
+  // game — same as the original behavior.
   // Strip any squashed sub-commit dump first so references that came from
   // already-merged branch history don't get re-attributed to this commit.
-  const message = stripSquashBlock(commit.message ?? "");
+  const scanTarget = messageDepth % 2 === 1 ? afterTitle : (commit.message ?? "");
+  const message = stripSquashBlock(scanTarget);
   if (message.length > 0) {
     for (const match of matchMagicWordIdentifiers(message)) {
       if (!found.has(match.identifier)) {
@@ -340,16 +343,34 @@ export function getRevertBranchDepth(branchName: string | null | undefined): num
   return parseRevertBranch(branchName).depth;
 }
 
-function parseRevertMessage(message: string): { depth: number; inner: string } {
-  let text = message;
+/**
+ * Unwrap `Revert "..."` layers found on the subject line only.
+ *
+ * The subject line is the canonical place where `git revert` writes the wrapper;
+ * scanning the whole message would let a stray `"` in the body close the regex
+ * far past the real subject, swallowing magic-word references the revert author
+ * added (e.g. `Fixes LIN-N` describing what the revert itself fixes) into the
+ * "reverted" pile. `afterTitle` collects everything that is NOT part of the
+ * unwrapped subject — both any trailing content on the subject line (such as
+ * `(#N)`) and the entire body — so callers can scan it for the revert author's
+ * own references.
+ */
+function parseRevertMessage(message: string): { depth: number; inner: string; afterTitle: string } {
+  const newlineIdx = message.search(/\r?\n/);
+  const subject = newlineIdx === -1 ? message : message.slice(0, newlineIdx);
+  const body = newlineIdx === -1 ? "" : message.slice(newlineIdx);
+
+  let text = subject;
   let depth = 0;
+  let outerAfter = "";
   while (/^Revert "/i.test(text)) {
-    const match = text.match(/^Revert "(.+)"(.*)$/s);
+    const match = text.match(/^Revert "(.+)"(.*)$/);
     if (!match) break;
+    if (depth === 0) outerAfter = match[2]!;
     text = match[1]!;
     depth++;
   }
-  return { depth, inner: text };
+  return { depth, inner: text, afterTitle: outerAfter + body };
 }
 
 /**

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -195,22 +195,26 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
     return [];
   }
 
-  // Odd depth = revert (skip); even depth = non-revert or revert-of-revert (re-add).
+  // Odd depth = revert; even depth = non-revert or revert-of-revert (re-add).
   const { depth: branchDepth, inner: strippedBranch } = parseRevertBranch(commit.branchName ?? "");
-  if (branchDepth % 2 === 1) {
-    verbose(`Skipping revert branch "${commit.branchName}" (depth ${branchDepth}) for commit ${commit.sha}`);
-    return [];
-  }
   const { depth: messageDepth, afterTitle } = parseRevertMessage(commit.message ?? "");
 
   const found = new Map<string, ExtractedIdentifier>();
 
-  if (strippedBranch.length > 0) {
+  // Odd-depth revert branches name what was *reverted* (e.g. `revert-456-eng-100-fix`),
+  // not what the revert itself adds — so the branch contributes no added identifiers.
+  // The body scan below still runs, since `Fixes ENG-N` in the revert message body
+  // is the revert author's own note about what they're closing.
+  if (branchDepth % 2 === 0 && strippedBranch.length > 0) {
     for (const match of matchAllIdentifiers(strippedBranch)) {
       if (!found.has(match.identifier)) {
         found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
       }
     }
+  } else if (branchDepth % 2 === 1) {
+    verbose(
+      `Skipping branch-name extraction for revert branch "${commit.branchName}" (depth ${branchDepth}) on ${commit.sha}`,
+    );
   }
 
   // In a revert, the inner subject's identifiers are reverted, not added — but

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -22,7 +22,10 @@ describe("scanCommits", () => {
         branchName: "revert-571-romain/bac-39",
         message: 'Merge pull request #572 from org/revert-571-romain/bac-39 Revert "Add TEST variable"',
       },
-      { sha: "ra1", message: 'Revert "Revert "Add TEST variable to .env.example""' },
+      {
+        sha: "ra1",
+        message: 'Revert "Revert "Add TEST variable to .env.example""',
+      },
       {
         sha: "ra2",
         branchName: "revert-572-revert-571-romain/bac-39",
@@ -52,8 +55,14 @@ describe("scanCommits", () => {
   describe("squash revert with magic word in message", () => {
     it("reverts identifier extracted from unwrapped message via magic word", () => {
       const commits: CommitContext[] = [
-        { sha: "a1", message: "Fixes DRIVE-320: memory leak in background location service" },
-        { sha: "r1", message: 'Revert "Fixes DRIVE-320: memory leak in background location service"' },
+        {
+          sha: "a1",
+          message: "Fixes DRIVE-320: memory leak in background location service",
+        },
+        {
+          sha: "r1",
+          message: 'Revert "Fixes DRIVE-320: memory leak in background location service"',
+        },
       ];
       const result = scanCommits(commits, null);
       expect(ids(result.issueReferences)).toEqual([]);
@@ -75,7 +84,11 @@ describe("scanCommits", () => {
     it("separates different issues into added and reverted lists", () => {
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100", message: "Fixes ENG-100" },
-        { sha: "r1", branchName: "revert-1-user/eng-200", message: 'Revert "ENG-200: something"' },
+        {
+          sha: "r1",
+          branchName: "revert-1-user/eng-200",
+          message: 'Revert "ENG-200: something"',
+        },
       ];
       const result = scanCommits(commits, null);
       expect(ids(result.issueReferences)).toEqual(["ENG-100"]);
@@ -85,7 +98,11 @@ describe("scanCommits", () => {
     it("reverts when same issue is added then reverted", () => {
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100" },
-        { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
+        {
+          sha: "r1",
+          branchName: "revert-1-user/eng-100",
+          message: 'Revert "ENG-100: fix"',
+        },
       ];
       const result = scanCommits(commits, null);
       expect(ids(result.issueReferences)).toEqual([]);
@@ -94,7 +111,11 @@ describe("scanCommits", () => {
 
     it("adds when same issue is reverted then re-added", () => {
       const commits: CommitContext[] = [
-        { sha: "r1", branchName: "revert-1-user/eng-100", message: 'Revert "ENG-100: fix"' },
+        {
+          sha: "r1",
+          branchName: "revert-1-user/eng-100",
+          message: 'Revert "ENG-100: fix"',
+        },
         { sha: "a1", branchName: "user/eng-100" },
       ];
       const result = scanCommits(commits, null);
@@ -102,7 +123,7 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual([]);
     });
 
-    it("body magic word adds the new issue when branch signals revert (LIN-69678 flow)", () => {
+    it("body magic word adds the new issue when branch signals revert", () => {
       // GitHub's auto-revert form: branch is `revert-<N>-<original>` and the
       // revert author's body note `Fixes ENG-200` claims a new issue is closed
       // by reverting. The branch inner names the reverted work (ENG-100); the

--- a/src/scan.test.ts
+++ b/src/scan.test.ts
@@ -102,19 +102,21 @@ describe("scanCommits", () => {
       expect(ids(result.revertedIssueReferences)).toEqual([]);
     });
 
-    it("reverts despite magic word in message when branch signals revert", () => {
-      // The branch name (revert-1-...) signals this is a revert, even though
-      // the message body contains "Fixes ENG-100" which would normally add it.
+    it("body magic word adds the new issue when branch signals revert (LIN-69678 flow)", () => {
+      // GitHub's auto-revert form: branch is `revert-<N>-<original>` and the
+      // revert author's body note `Fixes ENG-200` claims a new issue is closed
+      // by reverting. The branch inner names the reverted work (ENG-100); the
+      // body names the added work (ENG-200).
       const commits: CommitContext[] = [
         { sha: "a1", branchName: "user/eng-100" },
         {
           sha: "r1",
           branchName: "revert-1-user/eng-100",
-          message: "Merge pull request #2\n\nFixes ENG-100",
+          message: "Merge pull request #2\n\nFixes ENG-200",
         },
       ];
       const result = scanCommits(commits, null);
-      expect(ids(result.issueReferences)).toEqual([]);
+      expect(ids(result.issueReferences)).toEqual(["ENG-200"]);
       expect(ids(result.revertedIssueReferences)).toEqual(["ENG-100"]);
     });
 


### PR DESCRIPTION
Scan the body of revert commits for magic-word references — that's where manually added Fixes ENG-N notes live, not in the auto-generated Revert "..." subject. This fixes a bug in which the CLI ignored Fixes ENG-123 in a revert commit body, so the issue wasn't associated with the release.

  ## Examples

  ### A. Standard GitHub revert with a developer-added `Fixes`

  ```
  Revert "Original feature" (#456)

  Reverts org/repo#123

  Fixes ENG-123
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-123}` |
  | After | `{ENG-123}` | `{}` |

  ### B. Same shape but with quoted content in the body

  The case the greedy regex broke — the trailing `"` in the `img` tag closed the regex and swallowed the body.

  ```
  Revert "Original feature" (#456)

  Fixes ENG-123

  <img alt="screenshot" src="https://example.com/x.png" />
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-123}` |
  | After | `{ENG-123}` | `{}` |

  ### C. Magic word in both the inner subject and the body — split correctly

  ```
  Revert "Fixes ENG-100"

  Fixes ENG-123
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-100}` |
  | After | `{ENG-123}` | `{ENG-100}` |