### PR TITLE
Add 'test' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,6 @@ Path patterns can also be configured in your pipeline settings in Linear. If bot
 ## License
 
 Licensed under the [MIT License](./LICENSE).
+
+test
+


### PR DESCRIPTION
Scan the body of revert commits for magic-word references — that's where manually added Fixes ENG-N notes live, not in the auto-generated Revert "..." subject. This fixes a bug in which the CLI ignored Fixes ENG-123 in a revert commit body, so the issue wasn't associated with the release.

  ## Examples

  ### A. Standard GitHub revert with a developer-added `Fixes`

  ```
  Revert "Original feature" (#456)

  Reverts org/repo#123

  Fixes ENG-123
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-123}` |
  | After | `{ENG-123}` | `{}` |

  ### B. Same shape but with quoted content in the body

  The case the greedy regex broke — the trailing `"` in the `img` tag closed the regex and swallowed the body.

  ```
  Revert "Original feature" (#456)

  Fixes ENG-123

  <img alt="screenshot" src="https://example.com/x.png" />
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-123}` |
  | After | `{ENG-123}` | `{}` |

  ### C. Magic word in both the inner subject and the body — split correctly

  ```
  Revert "Fixes ENG-100"

  Fixes ENG-123
  ```

  | | `issues` | `revertedIssues` |
  |---|---|---|
  | Before | `{}` | `{ENG-100}` |
  | After | `{ENG-123}` | `{ENG-100}` |