### PR TITLE
Verify ancestor walkability on shallow clones in findBaseSha

### DIFF
--- a/src/base-sha.test.ts
+++ b/src/base-sha.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { findBaseSha, type FindBaseShaDeps } from "./base-sha";
-import { commitExists, ensureCommitAvailable, getCommitContextsBetweenShas, isAncestor } from "./git";
+import { getCommitContextsBetweenShas, verifyAncestorReachable } from "./git";
 import type { Release } from "./types";
 
 function runGit(args: string, cwd: string): string {
@@ -75,9 +75,7 @@ describe("findBaseSha", () => {
   beforeAll(() => {
     repo = buildRepo();
     deps = {
-      isAncestor: (sha, head) => isAncestor(sha, head, repo.cwd),
-      commitExists: (sha) => commitExists(sha, repo.cwd),
-      ensureCommitAvailable: (sha) => ensureCommitAvailable(sha, repo.cwd),
+      verifyAncestorReachable: (sha, head) => verifyAncestorReachable(sha, head, repo.cwd),
     };
   });
 
@@ -132,6 +130,67 @@ describe("findBaseSha", () => {
 });
 
 /**
+ * Same topology as scenario B but inside a true shallow clone of just HEAD
+ * (depth=1, detached HEAD, default refspec — the shape actions/checkout@v4
+ * produces for PR/tag/single-SHA builds). The trap: side-branch deepening
+ * pulls A's object into the DB as B's boundary parent without extending
+ * main's shallow graft, so `commitExists(A)` is true but A is still beyond
+ * the walk horizon from C. See `verifyAncestorReachable` in `git.ts`.
+ */
+describe("findBaseSha — shallow clone with sibling release branch", () => {
+  let origin: string;
+  let ci: string;
+  let A: string; // 1.52.0 on main, ~252 commits before HEAD
+  let B: string; // 1.52.1 on release/1.52, NOT on main
+  let C: string; // 1.53.0 HEAD on main
+  let deps: FindBaseShaDeps;
+
+  beforeAll(() => {
+    origin = mkdtempSync(join(tmpdir(), "lr-origin-shallow-"));
+    runGit("init -q -b main", origin);
+    runGit('config user.email "t@t"', origin);
+    runGit('config user.name "t"', origin);
+    commit(origin, "f", "0", "root");
+    A = commit(origin, "f", "A", "A (1.52.0 release on main)");
+
+    runGit(`checkout -q -b release/1.52 ${A}`, origin);
+    B = commit(origin, "f", "B", "B (1.52.1 hotfix on release/1.52)");
+
+    // 250 main commits past A so A sits beyond the first deepen step (200).
+    runGit("checkout -q main", origin);
+    for (let i = 0; i < 250; i++) commit(origin, `m${i}`, `${i}`, `main commit ${i}`);
+    C = commit(origin, "f", "C", "C (1.53.0 HEAD on main)");
+
+    // file:// forces the wire protocol so --depth actually applies — local
+    // paths hardlink the full pack. The default `+refs/heads/*` refspec stays
+    // present so subsequent fetches pull all branches, including release/1.52.
+    ci = mkdtempSync(join(tmpdir(), "lr-ci-shallow-"));
+    runGit("init -q", ci);
+    runGit(`remote add origin "file://${origin}"`, ci);
+    runGit(`config --add remote.origin.fetch "+${C}:refs/remotes/pull/0"`, ci);
+    runGit(`fetch --no-tags --prune --depth=1 origin "+${C}:refs/remotes/pull/0"`, ci);
+    runGit(`checkout --force ${C}`, ci);
+
+    deps = {
+      verifyAncestorReachable: (sha, head) => verifyAncestorReachable(sha, head, ci),
+    };
+  });
+
+  afterAll(() => {
+    if (origin) rmSync(origin, { recursive: true, force: true });
+    if (ci) rmSync(ci, { recursive: true, force: true });
+  });
+
+  it("picks main-train release A even though A's object was pulled in as a side-branch boundary", () => {
+    const candidates = [
+      release("1.52.1", B, 3), // side-branch candidate first (sorted by createdAt DESC)
+      release("1.52.0", A, 10),
+    ];
+    expect(findBaseSha(candidates, C, deps)).toEqual({ kind: "found", sha: A });
+  });
+});
+
+/**
  * Pairs scenario B's base selection with the actual `git log` range
  * computation: instead of asserting only on the picked SHA, feed it into
  * `getCommitContextsBetweenShas` and check the resulting commit list. Makes
@@ -147,9 +206,7 @@ describe("end-to-end: concurrent trains", () => {
   beforeAll(() => {
     repo = buildRepo();
     deps = {
-      isAncestor: (sha, head) => isAncestor(sha, head, repo.cwd),
-      commitExists: (sha) => commitExists(sha, repo.cwd),
-      ensureCommitAvailable: (sha) => ensureCommitAvailable(sha, repo.cwd),
+      verifyAncestorReachable: (sha, head) => verifyAncestorReachable(sha, head, repo.cwd),
     };
     // Hotfix sorts ahead of the main-train release in the candidate list.
     candidates = [release("1.70.1", repo.hotfixSha, 3), release("1.71.0", repo.mainPrev, 10)];

--- a/src/base-sha.ts
+++ b/src/base-sha.ts
@@ -4,9 +4,7 @@ import type { Release } from "./types";
 export type BaseShaResult = { kind: "found"; sha: string } | { kind: "fallback" };
 
 export type FindBaseShaDeps = {
-  isAncestor: (sha: string, headSha: string) => boolean;
-  commitExists: (sha: string) => boolean;
-  ensureCommitAvailable: (sha: string) => void;
+  verifyAncestorReachable: (sha: string, headSha: string) => boolean;
 };
 
 /**
@@ -14,9 +12,6 @@ export type FindBaseShaDeps = {
  * release candidates (most-relevant first). Returns the first candidate whose
  * `commitSha` is reachable from `headSha` — the API can't disambiguate
  * concurrent release trains via SQL alone, so we use git as ground truth.
- *
- * `commitExists` gates `ensureCommitAvailable` so a shallow clone doesn't pay
- * a `git fetch` per candidate when the SHAs are already local.
  */
 export function findBaseSha(candidates: Release[], headSha: string, deps: FindBaseShaDeps): BaseShaResult {
   for (const candidate of candidates) {
@@ -25,16 +20,7 @@ export function findBaseSha(candidates: Release[], headSha: string, deps: FindBa
       verbose(`Skipping base SHA candidate "${candidate.name}": no commit SHA`);
       continue;
     }
-    if (!deps.commitExists(sha)) {
-      try {
-        deps.ensureCommitAvailable(sha);
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        verbose(`Skipping base SHA candidate "${candidate.name}" (${sha.slice(0, 7)}): ${message}`);
-        continue;
-      }
-    }
-    if (!deps.isAncestor(sha, headSha)) {
+    if (!deps.verifyAncestorReachable(sha, headSha)) {
       verbose(
         `Skipping base SHA candidate "${candidate.name}" (${sha.slice(0, 7)}): not an ancestor of ${headSha.slice(0, 7)}`,
       );

--- a/src/git.ts
+++ b/src/git.ts
@@ -171,6 +171,11 @@ export function commitExists(sha: string, cwd: string = process.cwd()): boolean 
  * Used to verify that a candidate base SHA is actually on HEAD's history before
  * we hand it to `git log <base>..<HEAD>` — a candidate from a side branch (e.g.
  * a hotfix release) will scan a wrong range otherwise.
+ *
+ * Caveat on shallow clones: `git merge-base --is-ancestor` exits 1 both when
+ * `sha` is genuinely not an ancestor AND when the walk hits a shallow boundary
+ * before reaching `sha`. Callers that need to disambiguate should use
+ * `verifyAncestorReachable`, which deepens and retries on shallow cutoffs.
  */
 export function isAncestor(sha: string, headSha: string, cwd: string = process.cwd()): boolean {
   try {
@@ -182,6 +187,78 @@ export function isAncestor(sha: string, headSha: string, cwd: string = process.c
   } catch {
     return false;
   }
+}
+
+/** Returns true if the repository at `cwd` is a shallow clone, false otherwise. */
+export function isShallowRepository(cwd: string = process.cwd()): boolean {
+  try {
+    const out = execSync("git rev-parse --is-shallow-repository", {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return out.trim() === "true";
+  } catch {
+    return false;
+  }
+}
+
+const DEEPEN_STRATEGIES = [
+  { command: "git fetch --deepen=200 origin", label: "Deepening by 200 commits" },
+  { command: "git fetch --deepen=500 origin", label: "Deepening by 500 commits" },
+  { command: "git fetch --unshallow origin", label: "Fetching full history" },
+];
+
+function deepenUntil(cwd: string, check: () => boolean): boolean {
+  for (const { command, label } of DEEPEN_STRATEGIES) {
+    verbose(label);
+    try {
+      execSync(command, { cwd, stdio: ["ignore", "ignore", "pipe"], timeout: 30_000 });
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      verbose(`Strategy "${label}" failed: ${reason}`);
+      continue;
+    }
+    if (check()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns true if `sha` is an ancestor of `headSha`, deepening a shallow clone
+ * as needed to obtain a definitive answer.
+ *
+ * `isAncestor` alone isn't enough on shallow repos: `merge-base --is-ancestor`
+ * exits 1 both for genuine non-ancestors and for walks that hit a shallow graft
+ * before reaching `sha` — the two cases share an exit code. And `commitExists`
+ * can return true for an object that was pulled in as a side-branch boundary
+ * parent even when that commit isn't yet walkable from `headSha`. Disambiguate
+ * by deepening and retrying.
+ */
+export function verifyAncestorReachable(sha: string, headSha: string, cwd: string = process.cwd()): boolean {
+  if (sha === headSha) {
+    return true;
+  }
+
+  const isReachable = () => commitExists(sha, cwd) && isAncestor(sha, headSha, cwd);
+
+  if (isReachable()) {
+    return true;
+  }
+  if (!isShallowRepository(cwd)) {
+    // Deep repo: this negative is real, not a shallow cutoff.
+    return false;
+  }
+
+  verbose(`Cannot confirm ${sha.slice(0, 7)} is an ancestor of ${headSha.slice(0, 7)} on shallow repo; deepening`);
+
+  if (deepenUntil(cwd, isReachable)) {
+    verbose(`Confirmed ${sha.slice(0, 7)} is an ancestor of ${headSha.slice(0, 7)}`);
+    return true;
+  }
+  return false;
 }
 
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
@@ -254,32 +331,11 @@ export function ensureCommitAvailable(sha: string, cwd: string = process.cwd()):
     return;
   }
 
-  const strategies = [
-    {
-      command: "git fetch --deepen=200 origin",
-      label: "Deepening by 200 commits",
-    },
-    {
-      command: "git fetch --deepen=500 origin",
-      label: "Deepening by 500 commits",
-    },
-    { command: "git fetch --unshallow origin", label: "Fetching full history" },
-  ];
-
   verbose(`Commit ${sha} not in local history (likely shallow clone)`);
 
-  for (const { command, label } of strategies) {
-    verbose(label);
-    try {
-      execSync(command, { cwd, stdio: ["ignore", "ignore", "pipe"], timeout: 30_000 });
-      if (commitExists(sha, cwd)) {
-        verbose(`Found commit ${sha}`);
-        return;
-      }
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      verbose(`Strategy "${label}" failed: ${reason}`);
-    }
+  if (deepenUntil(cwd, () => commitExists(sha, cwd))) {
+    verbose(`Found commit ${sha}`);
+    return;
   }
 
   const currentBranch = getCurrentGitInfo(cwd).branch ?? "unknown";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,12 @@
 import { LinearClient, LinearClientOptions } from "@linear/sdk";
 import {
   assertGitAvailable,
-  commitExists,
   ensureCommitAvailable,
   getCommitContextsBetweenShas,
   getCurrentGitInfo,
   getRepoInfo,
-  isAncestor,
   resolveFirstSyncBoundary,
+  verifyAncestorReachable,
 } from "./git";
 import { findBaseSha } from "./base-sha";
 import { scanCommits } from "./scan";
@@ -342,7 +341,7 @@ async function getLatestSha(): Promise<string> {
   }
 
   const candidates = await getRecentReleases();
-  const result = findBaseSha(candidates, currentSha, { isAncestor, commitExists, ensureCommitAvailable });
+  const result = findBaseSha(candidates, currentSha, { verifyAncestorReachable });
   if (result.kind === "found") {
     return result.sha;
   }


### PR DESCRIPTION
When `findBaseSha` checks whether a candidate release's commit is an ancestor of HEAD, it previously gated `git merge-base --is-ancestor` on `commitExists`. That gate misfires on shallow CI clones: a side-branch deepening fetch can pull a sibling commit as a boundary parent without extending main's shallow. The object is local but not walkable from HEAD, and `merge-base --is-ancestor` exits 1 in that case, the same exit code as a genuine non-ancestor, so the candidate is silently rejected.

End-to-end effect: in a `main` + long-lived release-branch workflow, a `sync --release-version=…` on main after a release-branch sync would fall through to the empty-range path, skip release creation, and 404 on the next `update --stage=…`. 

Fix: replace the `commitExists` + `ensureCommitAvailable` + `isAncestor` with one atomic `verifyAncestorReachable` that deepens iteratively and only treats a negative as definitive once the repo is fully unshallowed.

Includes a regression test that reproduces the failure inside a real shallow clone.

---

Will also add a new flag in another PR, likely `--base-commit` or something similar, so that we can allow users to set the base commit explicitly to avoid relying on the ancestor-walk heuristic.