### PR TITLE
Add broader for matching issues identifiers

### DIFF
--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -412,16 +412,16 @@ describe("bracketed identifier in commit subject", () => {
     const result = extractLinearIssueIdentifiersForCommit({
       sha: "abc",
       branchName: null,
-      message: "[lin-456] adjust thing",
+      message: "[eng-123] adjust thing",
     });
-    expect(ids(result)).toEqual(["LIN-456"]);
+    expect(ids(result)).toEqual(["ENG-123"]);
   });
 
   it("does not extract bracketed identifier from elsewhere in the message", () => {
     const result = extractLinearIssueIdentifiersForCommit({
       sha: "abc",
       branchName: null,
-      message: "Title\n\nSee [LIN-999] in the docs",
+      message: "Title\n\nSee [ENG-123] in the docs",
     });
     expect(ids(result)).toEqual([]);
   });

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -398,6 +398,35 @@ describe("commit message magic word behavior", () => {
   });
 });
 
+describe("bracketed identifier in commit subject", () => {
+  it("extracts identifier from a [KEY-N] prefix on the subject line", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "[ENG-123] My change",
+    });
+    expect(ids(result)).toEqual(["ENG-123"]);
+  });
+
+  it("extracts identifier from a lowercase [key-n] prefix", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "[lin-456] adjust thing",
+    });
+    expect(ids(result)).toEqual(["LIN-456"]);
+  });
+
+  it("does not extract bracketed identifier from elsewhere in the message", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "Title\n\nSee [LIN-999] in the docs",
+    });
+    expect(ids(result)).toEqual([]);
+  });
+});
+
 describe("revert branch handling", () => {
   it("blocks extraction from merge commit with revert branch name", () => {
     const result = extractLinearIssueIdentifiersForCommit({

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -425,6 +425,33 @@ describe("bracketed identifier in commit subject", () => {
     });
     expect(ids(result)).toEqual([]);
   });
+
+  it("extracts identifier from a parenthesized (KEY-N) prefix on the subject line", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "(ENG-123) My change",
+    });
+    expect(ids(result)).toEqual(["ENG-123"]);
+  });
+
+  it("extracts identifier from a bare KEY-N prefix on the subject line", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "ENG-123 My change",
+    });
+    expect(ids(result)).toEqual(["ENG-123"]);
+  });
+
+  it("does not extract bare prefix when the subject does not start with it", () => {
+    const result = extractLinearIssueIdentifiersForCommit({
+      sha: "abc",
+      branchName: null,
+      message: "My change for ENG-123",
+    });
+    expect(ids(result)).toEqual([]);
+  });
 });
 
 describe("revert branch handling", () => {

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -35,6 +35,18 @@ const ISSUE_IDENTIFIER_REGEX = new RegExp(
 const LINEAR_ISSUE_URL_REGEX = /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-[0-9]{1,9})(?:\/[\w-]*)*/gi;
 
 /**
+ * Patterns for common manual subject-line conventions that aren't gated by a
+ * magic word. Each regex is anchored to the start of the subject and must
+ * capture team key in group 1 and issue number in group 2.
+ *
+ * Add more entries here as new conventions appear in the wild.
+ */
+const COMMON_SUBJECT_PATTERNS: RegExp[] = [
+  // `[ENG-123] My change`
+  new RegExp(`^\\s*\\[(\\w{1,${MAX_KEY_LENGTH}})-([0-9]{1,9})\\]`, "i"),
+];
+
+/**
  * `git merge --squash` followed by `git commit` writes a body containing this
  * header and then dumps the full message of every commit pulled in via the
  * squash — including upstream history merged into the feature branch via
@@ -161,6 +173,28 @@ function matchAllIdentifiers(text: string): IdentifierMatch[] {
 }
 
 /**
+ * Extract identifiers from common, manually-written subject-line conventions
+ * (e.g. `[ENG-123] My change`). These don't require a magic word — the
+ * convention itself signals intent.
+ */
+function matchCommonSubjectPatterns(message: string): IdentifierMatch[] {
+  const subject = message.split(/\r?\n/)[0] ?? "";
+  const results: IdentifierMatch[] = [];
+  for (const pattern of COMMON_SUBJECT_PATTERNS) {
+    const match = subject.match(pattern);
+    if (!match) continue;
+    const [, teamKey, numberString] = match;
+    if (!teamKey || !numberString) continue;
+    if (Number(numberString).toString().length !== numberString.length) continue;
+    results.push({
+      rawIdentifier: `${teamKey}-${numberString}`,
+      identifier: `${teamKey.toUpperCase()}-${Number(numberString)}`,
+    });
+  }
+  return results;
+}
+
+/**
  * Extract issue identifiers from text only when preceded by a magic word.
  * Processes text line-by-line, matching Linear's detection behavior.
  */
@@ -224,7 +258,7 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
   const scanTarget = messageDepth % 2 === 1 ? afterTitle : (commit.message ?? "");
   const message = stripSquashBlock(scanTarget);
   if (message.length > 0) {
-    for (const match of matchMagicWordIdentifiers(message)) {
+    for (const match of [...matchCommonSubjectPatterns(message), ...matchMagicWordIdentifiers(message)]) {
       if (!found.has(match.identifier)) {
         found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
       }

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -44,6 +44,10 @@ const LINEAR_ISSUE_URL_REGEX = /https?:\/\/linear\.app\/[\w-]+\/issue\/(\w{1,7}-
 const COMMON_SUBJECT_PATTERNS: RegExp[] = [
   // `[ENG-123] My change`
   new RegExp(`^\\s*\\[(\\w{1,${MAX_KEY_LENGTH}})-([0-9]{1,9})\\]`, "i"),
+  // `(ENG-123) My change`
+  new RegExp(`^\\s*\\((\\w{1,${MAX_KEY_LENGTH}})-([0-9]{1,9})\\)`, "i"),
+  // `ENG-123 My change`
+  new RegExp(`^\\s*(\\w{1,${MAX_KEY_LENGTH}})-([0-9]{1,9})(?=\\s)`, "i"),
 ];
 
 /**
@@ -242,7 +246,10 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
   if (branchDepth % 2 === 0 && strippedBranch.length > 0) {
     for (const match of matchAllIdentifiers(strippedBranch)) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
+        found.set(match.identifier, {
+          identifier: match.identifier,
+          source: "branch_name",
+        });
       }
     }
   } else if (branchDepth % 2 === 1) {
@@ -260,7 +267,10 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
   if (message.length > 0) {
     for (const match of [...matchCommonSubjectPatterns(message), ...matchMagicWordIdentifiers(message)]) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
+        found.set(match.identifier, {
+          identifier: match.identifier,
+          source: "commit_message",
+        });
       }
     }
   }
@@ -325,10 +335,18 @@ function extractGithubPrNumbers(message: string): PrMatch[] {
   const title = message.split(/\r?\n/)[0] ?? "";
 
   const squash = title.match(GITHUB_SQUASH_RE);
-  if (squash) matches.push({ number: Number.parseInt(squash[1]!, 10), source: "github squash" });
+  if (squash)
+    matches.push({
+      number: Number.parseInt(squash[1]!, 10),
+      source: "github squash",
+    });
 
   const merge = message.match(GITHUB_MERGE_RE);
-  if (merge) matches.push({ number: Number.parseInt(merge[1]!, 10), source: "github merge" });
+  if (merge)
+    matches.push({
+      number: Number.parseInt(merge[1]!, 10),
+      source: "github merge",
+    });
 
   // Fallback for non-canonical merge titles (e.g. a direct push that put the PR
   // number somewhere other than the trailing parens). Restrict to the title —
@@ -336,7 +354,10 @@ function extractGithubPrNumbers(message: string): PrMatch[] {
   // and stale references inside squashed-in sub-commit history.
   if (matches.length === 0) {
     for (const m of title.matchAll(GITHUB_TITLE_SCAN_RE)) {
-      matches.push({ number: Number.parseInt(m[1]!, 10), source: "github title scan" });
+      matches.push({
+        number: Number.parseInt(m[1]!, 10),
+        source: "github title scan",
+      });
     }
   }
 
@@ -382,7 +403,11 @@ export function getRevertBranchDepth(branchName: string | null | undefined): num
  * content on the subject line plus the body), so callers can scan it for the
  * revert author's own references.
  */
-function parseRevertMessage(message: string): { depth: number; inner: string; afterTitle: string } {
+function parseRevertMessage(message: string): {
+  depth: number;
+  inner: string;
+  afterTitle: string;
+} {
   const newlineIdx = message.search(/\r?\n/);
   const subject = newlineIdx === -1 ? message : message.slice(0, newlineIdx);
   const body = newlineIdx === -1 ? "" : message.slice(newlineIdx);
@@ -424,7 +449,10 @@ export function extractRevertedIssueIdentifiersForCommit(commit: CommitContext):
   if (branchDepth % 2 === 1) {
     for (const match of matchAllIdentifiers(originalBranch)) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, { identifier: match.identifier, source: "branch_name" });
+        found.set(match.identifier, {
+          identifier: match.identifier,
+          source: "branch_name",
+        });
       }
     }
   }
@@ -435,7 +463,10 @@ export function extractRevertedIssueIdentifiersForCommit(commit: CommitContext):
     const innerStripped = stripSquashBlock(innerMessage);
     for (const match of matchMagicWordIdentifiers(innerStripped)) {
       if (!found.has(match.identifier)) {
-        found.set(match.identifier, { identifier: match.identifier, source: "commit_message" });
+        found.set(match.identifier, {
+          identifier: match.identifier,
+          source: "commit_message",
+        });
       }
     }
   }


### PR DESCRIPTION
Updates the commit scanning to also pick up issue identifiers in commits when the identifier is enclosed in brackets, such as `[ENG-123] My change`. We support this when linking diffs and issues, so makes sense to also support this here.

Relates to https://github.com/linear/linear-release/pull/71