### PR TITLE
Bump package.json to 0.11.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-release",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "CLI tool to integrate CI/CD pipelines with Linear releases",
   "homepage": "https://github.com/linear/linear-release",


### PR DESCRIPTION
Release 0.11.1

After this PR is merged, the `v0.11.1` tag will be created automatically, triggering the release workflow.