### PR TITLE
Add --base-ref to manually override scan base

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ linear-release update --stage="in review" --name="Release 1.2.0"
 | `--release-version` | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, selects an existing release with that version (errors if none exists); does not change a release's version. If omitted, targets the most recent started release. |
 | `--stage`           | `update`                     | Target deployment stage (required for `update`)                                                                                                                                                                                                                      |
 | `--include-paths`   | `sync`                       | Filter commits by changed file paths                                                                                                                                                                                                                                 |
+| `--base-ref`        | `sync`                       | One-time scan base override for initialization or migration. Exclusive: scans `<base-ref>..HEAD`.                                                                                                                                                                    |
 | `--json`            | `sync`, `complete`, `update` | Output result as JSON on stdout. Logs are emitted as JSON Lines (one object per line) on stderr.                                                                                                                                                                     |
 | `--quiet`           | `sync`, `complete`, `update` | Suppress info-level output. Warnings and errors are still printed.                                                                                                                                                                                                   |
 | `--verbose`         | `sync`, `complete`, `update` | Print detailed progress including debug diagnostics                                                                                                                                                                                                                  |
@@ -220,10 +221,23 @@ Path patterns can also be configured in your pipeline settings in Linear. If bot
 > [!NOTE]
 > **First sync**: when no prior release exists for the pipeline, only the current commit is scanned (there's no previous SHA to bound the range from).
 
+### Overriding the Scan Base
+
+Use `--base-ref` as a one-time initialization or migration escape hatch when Linear's previous release SHA is missing, unreachable, or incompatible with the current repository history.
+
+```bash
+linear-release sync --base-ref=<last-released-ref> --include-paths="apps/api/**"
+```
+
+The base ref is exclusive: linear-release scans `<base-ref>..HEAD`, matching Git range syntax. Pass the last commit, tag, or ref that should be treated as already released, not the first commit you want included.
+
+When `--base-ref` is accepted, the release is synced and current `HEAD` is stored as the new release baseline even if zero commits match `--include-paths`. Remove `--base-ref` after the successful sync; future runs should use the normal previous-release baseline. If a reachable previous release baseline already exists, linear-release rejects `--base-ref` to avoid repeatedly rescanning old history.
+
 ## Troubleshooting
 
 - **Unexpected release was updated/completed**: pass `--release-version` explicitly so the command does not target the latest started/planned release.
-- **No release created by `sync`**: if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
+- **No release created by `sync`**: without `--base-ref`, if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
+- **Need to backfill the first release or migrate rewritten history**: run `sync` once with `--base-ref=<ref>` to set an explicit scan base, then remove the flag.
 - **Stage update fails**: `--stage` matches first by exact name, then case-insensitively with dashes and underscores treated as spaces. If multiple stages normalize to the same value, pass the exact stage name to disambiguate.
 - **`sync --release-version` fails because the matching release is archived**: restore the archived release in Linear before re-syncing.
 - **Operation timed out**: the CLI aborts after 60 seconds by default. For large repositories or slow networks, increase the limit with `--timeout=120`.

--- a/README.md
+++ b/README.md
@@ -149,17 +149,17 @@ linear-release update --stage="in review" --name="Release 1.2.0"
 
 ### CLI Options
 
-| Option               | Commands                     | Description                                                                                                                                                                                                                                                          |
-| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`             | `sync`, `complete`, `update` | Custom release name. For `sync`, the value is applied to the targeted release — both newly created releases and existing ones get the provided name. For `complete` and `update`, sets the name on the targeted release.                                             |
-| `--release-version`  | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, selects an existing release with that version (errors if none exists); does not change a release's version. If omitted, targets the most recent started release. |
-| `--stage`            | `update`                     | Target deployment stage (required for `update`)                                                                                                                                                                                                                      |
-| `--include-paths`    | `sync`                       | Filter commits by changed file paths                                                                                                                                                                                                                                 |
-| `--initial-base-ref` | `sync`                       | One-time initial scan base for initialization or migration. Exclusive: scans `<initial-base-ref>..HEAD`.                                                                                                                                                             |
-| `--json`             | `sync`, `complete`, `update` | Output result as JSON on stdout. Logs are emitted as JSON Lines (one object per line) on stderr.                                                                                                                                                                     |
-| `--quiet`            | `sync`, `complete`, `update` | Suppress info-level output. Warnings and errors are still printed.                                                                                                                                                                                                   |
-| `--verbose`          | `sync`, `complete`, `update` | Print detailed progress including debug diagnostics                                                                                                                                                                                                                  |
-| `--timeout`          | `sync`, `complete`, `update` | Max duration in seconds before aborting (default: 60)                                                                                                                                                                                                                |
+| Option              | Commands                     | Description                                                                                                                                                                                                                                                          |
+| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name`            | `sync`, `complete`, `update` | Custom release name. For `sync`, the value is applied to the targeted release — both newly created releases and existing ones get the provided name. For `complete` and `update`, sets the name on the targeted release.                                             |
+| `--release-version` | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, selects an existing release with that version (errors if none exists); does not change a release's version. If omitted, targets the most recent started release. |
+| `--stage`           | `update`                     | Target deployment stage (required for `update`)                                                                                                                                                                                                                      |
+| `--include-paths`   | `sync`                       | Filter commits by changed file paths                                                                                                                                                                                                                                 |
+| `--base-ref`        | `sync`                       | Override the scan base. Exclusive: scans `<base-ref>..HEAD`.                                                                                                                                                                                                         |
+| `--json`            | `sync`, `complete`, `update` | Output result as JSON on stdout. Logs are emitted as JSON Lines (one object per line) on stderr.                                                                                                                                                                     |
+| `--quiet`           | `sync`, `complete`, `update` | Suppress info-level output. Warnings and errors are still printed.                                                                                                                                                                                                   |
+| `--verbose`         | `sync`, `complete`, `update` | Print detailed progress including debug diagnostics                                                                                                                                                                                                                  |
+| `--timeout`         | `sync`, `complete`, `update` | Max duration in seconds before aborting (default: 60)                                                                                                                                                                                                                |
 
 ### Command Targeting
 
@@ -221,23 +221,23 @@ Path patterns can also be configured in your pipeline settings in Linear. If bot
 > [!NOTE]
 > **First sync**: when no prior release exists for the pipeline, only the current commit is scanned (there's no previous SHA to bound the range from).
 
-### Setting the Initial Scan Base
+### Overriding the Scan Base
 
-Use `--initial-base-ref` as a one-time initialization or migration escape hatch when Linear's previous release SHA is missing, unreachable, or incompatible with the current repository history.
+Use `--base-ref` to explicitly choose the exclusive lower bound for `sync`'s commit scan. This is useful when the automatically selected release baseline is not the range you want for a custom branching workflow, first-time onboarding, or migration.
 
 ```bash
-linear-release sync --initial-base-ref=<last-released-ref> --include-paths="apps/api/**"
+linear-release sync --base-ref=<last-released-ref> --include-paths="apps/api/**"
 ```
 
-The initial base ref is exclusive: linear-release scans `<initial-base-ref>..HEAD`, matching Git range syntax. Pass the last commit, tag, or ref that should be treated as already released, not the first commit you want included.
+The base ref is exclusive: linear-release scans `<base-ref>..HEAD`, matching Git range syntax, and still applies any configured path filters. Pass the last commit, tag, or ref that should be treated as already released, not the first commit you want included.
 
-When `--initial-base-ref` is accepted, the release is synced and current `HEAD` is stored as the new release baseline even if zero commits match `--include-paths`. Remove `--initial-base-ref` after the successful sync; future runs should use the normal previous-release baseline. If a reachable previous release baseline already exists, linear-release rejects `--initial-base-ref` to avoid repeatedly rescanning old history.
+When `--base-ref` is provided, it overrides automatic base selection for that run. After sync, current `HEAD` is stored as the future release baseline. Choosing an older or newer base can reattach or skip commits, so use this only when you intentionally want to own the scan range.
 
 ## Troubleshooting
 
 - **Unexpected release was updated/completed**: pass `--release-version` explicitly so the command does not target the latest started/planned release.
-- **No release created by `sync`**: without `--initial-base-ref`, if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
-- **Need to backfill the first release or migrate rewritten history**: run `sync` once with `--initial-base-ref=<ref>` to set an explicit scan base, then remove the flag.
+- **No release created by `sync`**: without `--base-ref`, if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
+- **Need to backfill the first release, migrate rewritten history, or override the inferred range**: run `sync` with `--base-ref=<ref>` to set an explicit scan base.
 - **Stage update fails**: `--stage` matches first by exact name, then case-insensitively with dashes and underscores treated as spaces. If multiple stages normalize to the same value, pass the exact stage name to disambiguate.
 - **`sync --release-version` fails because the matching release is archived**: restore the archived release in Linear before re-syncing.
 - **Operation timed out**: the CLI aborts after 60 seconds by default. For large repositories or slow networks, increase the limit with `--timeout=120`.

--- a/README.md
+++ b/README.md
@@ -149,17 +149,17 @@ linear-release update --stage="in review" --name="Release 1.2.0"
 
 ### CLI Options
 
-| Option              | Commands                     | Description                                                                                                                                                                                                                                                          |
-| ------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`            | `sync`, `complete`, `update` | Custom release name. For `sync`, the value is applied to the targeted release — both newly created releases and existing ones get the provided name. For `complete` and `update`, sets the name on the targeted release.                                             |
-| `--release-version` | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, selects an existing release with that version (errors if none exists); does not change a release's version. If omitted, targets the most recent started release. |
-| `--stage`           | `update`                     | Target deployment stage (required for `update`)                                                                                                                                                                                                                      |
-| `--include-paths`   | `sync`                       | Filter commits by changed file paths                                                                                                                                                                                                                                 |
-| `--base-ref`        | `sync`                       | One-time scan base override for initialization or migration. Exclusive: scans `<base-ref>..HEAD`.                                                                                                                                                                    |
-| `--json`            | `sync`, `complete`, `update` | Output result as JSON on stdout. Logs are emitted as JSON Lines (one object per line) on stderr.                                                                                                                                                                     |
-| `--quiet`           | `sync`, `complete`, `update` | Suppress info-level output. Warnings and errors are still printed.                                                                                                                                                                                                   |
-| `--verbose`         | `sync`, `complete`, `update` | Print detailed progress including debug diagnostics                                                                                                                                                                                                                  |
-| `--timeout`         | `sync`, `complete`, `update` | Max duration in seconds before aborting (default: 60)                                                                                                                                                                                                                |
+| Option               | Commands                     | Description                                                                                                                                                                                                                                                          |
+| -------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name`             | `sync`, `complete`, `update` | Custom release name. For `sync`, the value is applied to the targeted release — both newly created releases and existing ones get the provided name. For `complete` and `update`, sets the name on the targeted release.                                             |
+| `--release-version`  | `sync`, `complete`, `update` | Release version identifier. For `sync`, defaults to short commit hash. For `complete` and `update`, selects an existing release with that version (errors if none exists); does not change a release's version. If omitted, targets the most recent started release. |
+| `--stage`            | `update`                     | Target deployment stage (required for `update`)                                                                                                                                                                                                                      |
+| `--include-paths`    | `sync`                       | Filter commits by changed file paths                                                                                                                                                                                                                                 |
+| `--initial-base-ref` | `sync`                       | One-time initial scan base for initialization or migration. Exclusive: scans `<initial-base-ref>..HEAD`.                                                                                                                                                             |
+| `--json`             | `sync`, `complete`, `update` | Output result as JSON on stdout. Logs are emitted as JSON Lines (one object per line) on stderr.                                                                                                                                                                     |
+| `--quiet`            | `sync`, `complete`, `update` | Suppress info-level output. Warnings and errors are still printed.                                                                                                                                                                                                   |
+| `--verbose`          | `sync`, `complete`, `update` | Print detailed progress including debug diagnostics                                                                                                                                                                                                                  |
+| `--timeout`          | `sync`, `complete`, `update` | Max duration in seconds before aborting (default: 60)                                                                                                                                                                                                                |
 
 ### Command Targeting
 
@@ -221,23 +221,23 @@ Path patterns can also be configured in your pipeline settings in Linear. If bot
 > [!NOTE]
 > **First sync**: when no prior release exists for the pipeline, only the current commit is scanned (there's no previous SHA to bound the range from).
 
-### Overriding the Scan Base
+### Setting the Initial Scan Base
 
-Use `--base-ref` as a one-time initialization or migration escape hatch when Linear's previous release SHA is missing, unreachable, or incompatible with the current repository history.
+Use `--initial-base-ref` as a one-time initialization or migration escape hatch when Linear's previous release SHA is missing, unreachable, or incompatible with the current repository history.
 
 ```bash
-linear-release sync --base-ref=<last-released-ref> --include-paths="apps/api/**"
+linear-release sync --initial-base-ref=<last-released-ref> --include-paths="apps/api/**"
 ```
 
-The base ref is exclusive: linear-release scans `<base-ref>..HEAD`, matching Git range syntax. Pass the last commit, tag, or ref that should be treated as already released, not the first commit you want included.
+The initial base ref is exclusive: linear-release scans `<initial-base-ref>..HEAD`, matching Git range syntax. Pass the last commit, tag, or ref that should be treated as already released, not the first commit you want included.
 
-When `--base-ref` is accepted, the release is synced and current `HEAD` is stored as the new release baseline even if zero commits match `--include-paths`. Remove `--base-ref` after the successful sync; future runs should use the normal previous-release baseline. If a reachable previous release baseline already exists, linear-release rejects `--base-ref` to avoid repeatedly rescanning old history.
+When `--initial-base-ref` is accepted, the release is synced and current `HEAD` is stored as the new release baseline even if zero commits match `--include-paths`. Remove `--initial-base-ref` after the successful sync; future runs should use the normal previous-release baseline. If a reachable previous release baseline already exists, linear-release rejects `--initial-base-ref` to avoid repeatedly rescanning old history.
 
 ## Troubleshooting
 
 - **Unexpected release was updated/completed**: pass `--release-version` explicitly so the command does not target the latest started/planned release.
-- **No release created by `sync`**: without `--base-ref`, if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
-- **Need to backfill the first release or migrate rewritten history**: run `sync` once with `--base-ref=<ref>` to set an explicit scan base, then remove the flag.
+- **No release created by `sync`**: without `--initial-base-ref`, if no commits match the computed range (or path filters), `sync` returns `{"release":null}`.
+- **Need to backfill the first release or migrate rewritten history**: run `sync` once with `--initial-base-ref=<ref>` to set an explicit scan base, then remove the flag.
 - **Stage update fails**: `--stage` matches first by exact name, then case-insensitively with dashes and underscores treated as spaces. If multiple stages normalize to the same value, pass the exact stage name to disambiguate.
 - **`sync --release-version` fails because the matching release is archived**: restore the archived release in Linear before re-syncing.
 - **Operation timed out**: the CLI aborts after 60 seconds by default. For large repositories or slow networks, increase the limit with `--timeout=120`.

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -43,6 +43,16 @@ describe("parseCLIArgs", () => {
     expect(result.stageName).toBe("production");
   });
 
+  it("parses --base-ref", () => {
+    const result = parseCLIArgs(["--base-ref", "v1.2.3"]);
+    expect(result.baseRef).toBe("v1.2.3");
+  });
+
+  it("parses --base-ref with = syntax", () => {
+    const result = parseCLIArgs(["--base-ref=main~5"]);
+    expect(result.baseRef).toBe("main~5");
+  });
+
   it("defaults --json to false", () => {
     const result = parseCLIArgs([]);
     expect(result.jsonOutput).toBe(false);

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -43,14 +43,14 @@ describe("parseCLIArgs", () => {
     expect(result.stageName).toBe("production");
   });
 
-  it("parses --base-ref", () => {
-    const result = parseCLIArgs(["--base-ref", "v1.2.3"]);
-    expect(result.baseRef).toBe("v1.2.3");
+  it("parses --initial-base-ref", () => {
+    const result = parseCLIArgs(["--initial-base-ref", "v1.2.3"]);
+    expect(result.initialBaseRef).toBe("v1.2.3");
   });
 
-  it("parses --base-ref with = syntax", () => {
-    const result = parseCLIArgs(["--base-ref=main~5"]);
-    expect(result.baseRef).toBe("main~5");
+  it("parses --initial-base-ref with = syntax", () => {
+    const result = parseCLIArgs(["--initial-base-ref=main~5"]);
+    expect(result.initialBaseRef).toBe("main~5");
   });
 
   it("defaults --json to false", () => {

--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -43,14 +43,14 @@ describe("parseCLIArgs", () => {
     expect(result.stageName).toBe("production");
   });
 
-  it("parses --initial-base-ref", () => {
-    const result = parseCLIArgs(["--initial-base-ref", "v1.2.3"]);
-    expect(result.initialBaseRef).toBe("v1.2.3");
+  it("parses --base-ref", () => {
+    const result = parseCLIArgs(["--base-ref", "v1.2.3"]);
+    expect(result.baseRef).toBe("v1.2.3");
   });
 
-  it("parses --initial-base-ref with = syntax", () => {
-    const result = parseCLIArgs(["--initial-base-ref=main~5"]);
-    expect(result.initialBaseRef).toBe("main~5");
+  it("parses --base-ref with = syntax", () => {
+    const result = parseCLIArgs(["--base-ref=main~5"]);
+    expect(result.baseRef).toBe("main~5");
   });
 
   it("defaults --json to false", () => {

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,7 +6,7 @@ export type ParsedCLIArgs = {
   releaseName?: string;
   releaseVersion?: string;
   stageName?: string;
-  initialBaseRef?: string;
+  baseRef?: string;
   includePaths: string[];
   jsonOutput: boolean;
   timeoutSeconds: number;
@@ -20,7 +20,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
       name: { type: "string" },
       "release-version": { type: "string" },
       stage: { type: "string" },
-      "initial-base-ref": { type: "string" },
+      "base-ref": { type: "string" },
       "include-paths": { type: "string" },
       json: { type: "boolean", default: false },
       timeout: { type: "string" },
@@ -54,7 +54,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     releaseName: values.name,
     releaseVersion: values["release-version"],
     stageName: values.stage,
-    initialBaseRef: values["initial-base-ref"],
+    baseRef: values["base-ref"],
     includePaths: values["include-paths"]
       ? values["include-paths"]
           .split(",")

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,6 +6,7 @@ export type ParsedCLIArgs = {
   releaseName?: string;
   releaseVersion?: string;
   stageName?: string;
+  baseRef?: string;
   includePaths: string[];
   jsonOutput: boolean;
   timeoutSeconds: number;
@@ -19,6 +20,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
       name: { type: "string" },
       "release-version": { type: "string" },
       stage: { type: "string" },
+      "base-ref": { type: "string" },
       "include-paths": { type: "string" },
       json: { type: "boolean", default: false },
       timeout: { type: "string" },
@@ -52,6 +54,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     releaseName: values.name,
     releaseVersion: values["release-version"],
     stageName: values.stage,
+    baseRef: values["base-ref"],
     includePaths: values["include-paths"]
       ? values["include-paths"]
           .split(",")

--- a/src/args.ts
+++ b/src/args.ts
@@ -6,7 +6,7 @@ export type ParsedCLIArgs = {
   releaseName?: string;
   releaseVersion?: string;
   stageName?: string;
-  baseRef?: string;
+  initialBaseRef?: string;
   includePaths: string[];
   jsonOutput: boolean;
   timeoutSeconds: number;
@@ -20,7 +20,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
       name: { type: "string" },
       "release-version": { type: "string" },
       stage: { type: "string" },
-      "base-ref": { type: "string" },
+      "initial-base-ref": { type: "string" },
       "include-paths": { type: "string" },
       json: { type: "boolean", default: false },
       timeout: { type: "string" },
@@ -54,7 +54,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     releaseName: values.name,
     releaseVersion: values["release-version"],
     stageName: values.stage,
-    baseRef: values["base-ref"],
+    initialBaseRef: values["initial-base-ref"],
     includePaths: values["include-paths"]
       ? values["include-paths"]
           .split(",")

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import type { CommitContext, GitInfo, RepoInfo } from "./types";
 import { error as logError, verbose, warn } from "./log";
 
@@ -264,6 +264,31 @@ export function verifyAncestorReachable(sha: string, headSha: string, cwd: strin
 const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 
 /**
+ * Resolves a git ref, tag, or SHA to a full commit SHA.
+ *
+ * Short/full SHAs in shallow clones may not resolve until history is deepened,
+ * so SHA-like inputs get the same availability treatment as release baselines.
+ */
+export function resolveCommitRef(ref: string, cwd: string = process.cwd()): string {
+  const resolve = () =>
+    execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+
+  try {
+    return resolve();
+  } catch {
+    if (SHA_PATTERN.test(ref)) {
+      ensureCommitAvailable(ref, cwd);
+      return resolve();
+    }
+    throw new Error(`Could not resolve "${ref}" to a commit. Use a valid commit SHA, tag, or ref.`);
+  }
+}
+
+/**
  * Extracts the branch name from a merge commit message.
  * Supports:
  *   - GitHub: "Merge pull request #X from owner/branch-name"
@@ -369,19 +394,21 @@ function runLog(rangeArgs: string, cwd: string): CommitContext[] {
  * `--no-walk` (only when `fromSha === toSha`): without it, `git log -1 <sha>
  * -- <paths>` walks back from `<sha>` to the first ancestor matching the
  * pathspec — silently returning an unrelated commit when `<sha>` itself
- * doesn't match.
+ * doesn't match. Callers that need true `sha..sha` empty-range semantics can
+ * pass `inspectSingleCommit: false`.
  *
  * @param fromSha - Starting commit SHA (exclusive)
  * @param toSha - Ending commit SHA (inclusive)
  * @param options.includePaths - Glob patterns to filter commits by file paths (relative to repo root)
+ * @param options.inspectSingleCommit - When SHAs match, inspect that one commit instead of treating it as an empty range
  * @param options.cwd - Working directory for git commands (defaults to process.cwd())
  */
 export function getCommitContextsBetweenShas(
   fromSha: string,
   toSha: string,
-  options: { includePaths?: string[] | null; cwd?: string } = {},
+  options: { includePaths?: string[] | null; inspectSingleCommit?: boolean; cwd?: string } = {},
 ): CommitContext[] {
-  const { includePaths = null, cwd = process.cwd() } = options;
+  const { includePaths = null, inspectSingleCommit = true, cwd = process.cwd() } = options;
 
   if (!SHA_PATTERN.test(fromSha)) {
     warn(`Invalid "from" SHA format "${fromSha}"`);
@@ -392,9 +419,10 @@ export function getCommitContextsBetweenShas(
     return [];
   }
 
+  const inspectingSingleCommit = fromSha === toSha && inspectSingleCommit;
   const args = [
     includePaths?.length ? "--full-history" : "",
-    fromSha === toSha ? `--no-walk ${toSha}` : `${fromSha}..${toSha}`,
+    inspectingSingleCommit ? `--no-walk ${toSha}` : `${fromSha}..${toSha}`,
     buildPathspecArgs(includePaths),
   ]
     .filter(Boolean)
@@ -402,7 +430,7 @@ export function getCommitContextsBetweenShas(
   const commits = runLog(args, cwd);
 
   if (commits.length === 0) {
-    if (fromSha === toSha) {
+    if (inspectingSingleCommit) {
       const pathFilter = includePaths?.length ? ` include paths: ${includePaths.join(", ")}` : "";
       verbose(`Commit ${toSha.slice(0, 7)} did not match${pathFilter}`);
     } else {

--- a/src/git.ts
+++ b/src/git.ts
@@ -266,12 +266,14 @@ const SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 /**
  * Resolves a git ref, tag, or SHA to a full commit SHA.
  *
- * Short/full SHAs in shallow clones may not resolve until history is deepened,
- * so SHA-like inputs get the same availability treatment as release baselines.
+ * Shallow or single-branch clones often lack the target locally:
+ *   - SHA-like inputs: deepen history until the commit is reachable.
+ *   - Tag or branch refs: `git fetch origin <ref>` populates FETCH_HEAD with
+ *     the resolved commit for both kinds, without needing to know which.
  */
 export function resolveCommitRef(ref: string, cwd: string = process.cwd()): string {
-  const resolve = () =>
-    execFileSync("git", ["rev-parse", "--verify", `${ref}^{commit}`], {
+  const resolve = (target: string = ref) =>
+    execFileSync("git", ["rev-parse", "--verify", `${target}^{commit}`], {
       cwd,
       stdio: ["ignore", "pipe", "ignore"],
       encoding: "utf8",
@@ -284,7 +286,17 @@ export function resolveCommitRef(ref: string, cwd: string = process.cwd()): stri
       ensureCommitAvailable(ref, cwd);
       return resolve();
     }
-    throw new Error(`Could not resolve "${ref}" to a commit. Use a valid commit SHA, tag, or ref.`);
+    try {
+      verbose(`Ref "${ref}" not in local history; fetching from origin`);
+      execFileSync("git", ["fetch", "origin", ref], {
+        cwd,
+        stdio: ["ignore", "ignore", "ignore"],
+        timeout: 30_000,
+      });
+      return resolve("FETCH_HEAD");
+    } catch {
+      throw new Error(`Could not resolve "${ref}" to a commit. Use a valid commit SHA, tag, or ref.`);
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -373,8 +373,7 @@ function getScanBase(candidates: Release[], currentSha: string): ScanBase {
       const detail = e instanceof Error ? e.message : String(e);
       throw new Error(`Invalid --base-ref: ${detail}`);
     }
-    warn("--base-ref provided; skipping automatic release baseline selection");
-    info(`Using --base-ref ${baseRef} resolved to ${resolvedSha.slice(0, 7)}`);
+    info(`Using --base-ref ${baseRef} (${resolvedSha.slice(0, 7)}); skipping automatic baseline selection`);
     return { kind: "base-ref", sha: resolvedSha, ref: baseRef };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,7 @@ import {
   resolveCommitRef,
   verifyAncestorReachable,
 } from "./git";
-import {
-  assertInitialBaseRefIsAncestor,
-  assertInitialBaseRefAllowed,
-  ScanBase,
-  selectAutomaticScanBase,
-  shouldCreateReleaseForScan,
-} from "./scan-base";
+import { assertBaseRefIsAncestor, ScanBase, selectAutomaticScanBase, shouldCreateReleaseForScan } from "./scan-base";
 import { scanCommits } from "./scan";
 import {
   Release,
@@ -57,7 +51,7 @@ Options:
   --release-version=<version>  Release version identifier
   --stage=<stage>            Deployment stage (required for update)
   --include-paths=<paths>    Filter commits by file paths (comma-separated globs)
-  --initial-base-ref=<ref>   One-time sync base for initialization/migration (exclusive; scans <ref>..HEAD)
+  --base-ref=<ref>           Override sync scan base (exclusive; scans <ref>..HEAD)
   --timeout=<seconds>        Abort if the operation exceeds this duration (default: 60)
   --json                     Output result as JSON (logs emitted as JSON Lines on stderr)
   --quiet                    Suppress info-level output (warnings and errors still printed)
@@ -74,7 +68,7 @@ Examples:
   linear-release complete
   linear-release update --stage=production
   linear-release sync --include-paths="apps/web/**,packages/**"
-  linear-release sync --initial-base-ref=<last-released-ref> --include-paths="apps/web/**"
+  linear-release sync --base-ref=<last-released-ref> --include-paths="apps/web/**"
 `);
   process.exit(0);
 }
@@ -94,17 +88,8 @@ try {
   error(`${message} (run linear-release --help for usage)`);
   process.exit(1);
 }
-const {
-  command,
-  releaseName,
-  releaseVersion,
-  stageName,
-  initialBaseRef,
-  includePaths,
-  jsonOutput,
-  timeoutSeconds,
-  logLevel,
-} = parsedArgs;
+const { command, releaseName, releaseVersion, stageName, baseRef, includePaths, jsonOutput, timeoutSeconds, logLevel } =
+  parsedArgs;
 const cliWarnings = getCLIWarnings(parsedArgs);
 setLogLevel(logLevel);
 if (jsonOutput) {
@@ -187,8 +172,8 @@ async function syncCommand(): Promise<{
   let latestSha = scanBase.sha;
   let inspectingOnlyCurrentCommit = false;
 
-  if (scanBase.kind === "initial-base-ref") {
-    assertInitialBaseRefIsAncestor(scanBase.ref, latestSha, currentCommit.commit, { verifyAncestorReachable });
+  if (scanBase.kind === "base-ref") {
+    assertBaseRefIsAncestor(scanBase.ref, latestSha, currentCommit.commit, { verifyAncestorReachable });
     const includePathSummary = effectiveIncludePaths?.length
       ? ` with include paths: ${effectiveIncludePaths.join(", ")}`
       : "";
@@ -208,7 +193,7 @@ async function syncCommand(): Promise<{
 
   const commits = getCommitContextsBetweenShas(latestSha, currentCommit.commit, {
     includePaths: effectiveIncludePaths,
-    inspectSingleCommit: scanBase.kind !== "initial-base-ref",
+    inspectSingleCommit: scanBase.kind !== "base-ref",
   });
 
   if (inspectingOnlyCurrentCommit) {
@@ -223,7 +208,7 @@ async function syncCommand(): Promise<{
     }
   } else {
     const commitNoun = effectiveIncludePaths?.length ? "matching commit" : "commit";
-    if (scanBase.kind === "initial-base-ref") {
+    if (scanBase.kind === "base-ref") {
       info(`Found ${commits.length} ${pluralize(commits.length, commitNoun)} in requested range`);
     } else if (latestSha === currentCommit.commit) {
       info(
@@ -239,14 +224,14 @@ async function syncCommand(): Promise<{
   if (commits.length === 0) {
     const reason = effectiveIncludePaths?.length
       ? `No matching commits found for include paths: ${effectiveIncludePaths.join(", ")}`
-      : scanBase.kind === "initial-base-ref"
+      : scanBase.kind === "base-ref"
         ? "No commits found in the requested range"
         : "No commits found in the computed range";
     if (!shouldCreateReleaseForScan(commits.length, scanBase)) {
       info(`${reason}. Skipping release creation.`);
       return null;
     }
-    info(`${reason}. Syncing release anyway because --initial-base-ref was provided to establish the baseline.`);
+    info(`${reason}. Syncing release anyway because --base-ref was provided to establish the baseline.`);
   }
 
   // git log returns newest-first; scanCommits needs chronological (oldest-first) for last-write-wins
@@ -272,7 +257,7 @@ async function syncCommand(): Promise<{
   if (prNumbers.length > 0) parts.push(`pull requests [${prNumbers.map((n) => `#${n}`).join(", ")}]`);
   const attached = parts.length > 0 ? parts.join(", ") : "no new issues or pull requests";
   info(`Synced to release ${release.name} (${formatVersion(release)}): ${attached}`);
-  if (scanBase.kind === "initial-base-ref") {
+  if (scanBase.kind === "base-ref") {
     info(`Stored release baseline: ${(release.commitSha ?? currentCommit.commit).slice(0, 7)}`);
   }
 
@@ -380,22 +365,17 @@ async function getRecentReleases(): Promise<Release[]> {
 }
 
 function getScanBase(candidates: Release[], currentSha: string): ScanBase {
-  if (initialBaseRef) {
-    const previousBaseline = assertInitialBaseRefAllowed(candidates, currentSha, { verifyAncestorReachable });
+  if (baseRef) {
     let resolvedSha: string;
     try {
-      resolvedSha = resolveCommitRef(initialBaseRef);
+      resolvedSha = resolveCommitRef(baseRef);
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
-      throw new Error(`Invalid --initial-base-ref: ${detail}`);
+      throw new Error(`Invalid --base-ref: ${detail}`);
     }
-    info(`Using --initial-base-ref ${initialBaseRef} resolved to ${resolvedSha.slice(0, 7)}`);
-    if (previousBaseline === "unreachable") {
-      warn("No reachable previous release baseline found; using --initial-base-ref as the scan base");
-    } else {
-      verbose("No recent releases found; using --initial-base-ref as the scan base");
-    }
-    return { kind: "initial-base-ref", sha: resolvedSha, ref: initialBaseRef };
+    warn("--base-ref provided; skipping automatic release baseline selection");
+    info(`Using --base-ref ${baseRef} resolved to ${resolvedSha.slice(0, 7)}`);
+    return { kind: "base-ref", sha: resolvedSha, ref: baseRef };
   }
 
   const scanBase = selectAutomaticScanBase(candidates, currentSha, { verifyAncestorReachable });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,8 @@ import {
   verifyAncestorReachable,
 } from "./git";
 import {
-  assertBaseRefIsAncestor,
-  assertBaseRefAllowed,
+  assertInitialBaseRefIsAncestor,
+  assertInitialBaseRefAllowed,
   ScanBase,
   selectAutomaticScanBase,
   shouldCreateReleaseForScan,
@@ -57,7 +57,7 @@ Options:
   --release-version=<version>  Release version identifier
   --stage=<stage>            Deployment stage (required for update)
   --include-paths=<paths>    Filter commits by file paths (comma-separated globs)
-  --base-ref=<ref>           One-time sync base override for initialization/migration (exclusive; scans <ref>..HEAD)
+  --initial-base-ref=<ref>   One-time sync base for initialization/migration (exclusive; scans <ref>..HEAD)
   --timeout=<seconds>        Abort if the operation exceeds this duration (default: 60)
   --json                     Output result as JSON (logs emitted as JSON Lines on stderr)
   --quiet                    Suppress info-level output (warnings and errors still printed)
@@ -74,7 +74,7 @@ Examples:
   linear-release complete
   linear-release update --stage=production
   linear-release sync --include-paths="apps/web/**,packages/**"
-  linear-release sync --base-ref=<last-released-ref> --include-paths="apps/web/**"
+  linear-release sync --initial-base-ref=<last-released-ref> --include-paths="apps/web/**"
 `);
   process.exit(0);
 }
@@ -94,8 +94,17 @@ try {
   error(`${message} (run linear-release --help for usage)`);
   process.exit(1);
 }
-const { command, releaseName, releaseVersion, stageName, baseRef, includePaths, jsonOutput, timeoutSeconds, logLevel } =
-  parsedArgs;
+const {
+  command,
+  releaseName,
+  releaseVersion,
+  stageName,
+  initialBaseRef,
+  includePaths,
+  jsonOutput,
+  timeoutSeconds,
+  logLevel,
+} = parsedArgs;
 const cliWarnings = getCLIWarnings(parsedArgs);
 setLogLevel(logLevel);
 if (jsonOutput) {
@@ -178,8 +187,8 @@ async function syncCommand(): Promise<{
   let latestSha = scanBase.sha;
   let inspectingOnlyCurrentCommit = false;
 
-  if (scanBase.kind === "base-ref") {
-    assertBaseRefIsAncestor(scanBase.ref, latestSha, currentCommit.commit, { verifyAncestorReachable });
+  if (scanBase.kind === "initial-base-ref") {
+    assertInitialBaseRefIsAncestor(scanBase.ref, latestSha, currentCommit.commit, { verifyAncestorReachable });
     const includePathSummary = effectiveIncludePaths?.length
       ? ` with include paths: ${effectiveIncludePaths.join(", ")}`
       : "";
@@ -199,7 +208,7 @@ async function syncCommand(): Promise<{
 
   const commits = getCommitContextsBetweenShas(latestSha, currentCommit.commit, {
     includePaths: effectiveIncludePaths,
-    inspectSingleCommit: scanBase.kind !== "base-ref",
+    inspectSingleCommit: scanBase.kind !== "initial-base-ref",
   });
 
   if (inspectingOnlyCurrentCommit) {
@@ -214,7 +223,7 @@ async function syncCommand(): Promise<{
     }
   } else {
     const commitNoun = effectiveIncludePaths?.length ? "matching commit" : "commit";
-    if (scanBase.kind === "base-ref") {
+    if (scanBase.kind === "initial-base-ref") {
       info(`Found ${commits.length} ${pluralize(commits.length, commitNoun)} in requested range`);
     } else if (latestSha === currentCommit.commit) {
       info(
@@ -230,14 +239,14 @@ async function syncCommand(): Promise<{
   if (commits.length === 0) {
     const reason = effectiveIncludePaths?.length
       ? `No matching commits found for include paths: ${effectiveIncludePaths.join(", ")}`
-      : scanBase.kind === "base-ref"
+      : scanBase.kind === "initial-base-ref"
         ? "No commits found in the requested range"
         : "No commits found in the computed range";
     if (!shouldCreateReleaseForScan(commits.length, scanBase)) {
       info(`${reason}. Skipping release creation.`);
       return null;
     }
-    info(`${reason}. Syncing release anyway because --base-ref was provided to establish the baseline.`);
+    info(`${reason}. Syncing release anyway because --initial-base-ref was provided to establish the baseline.`);
   }
 
   // git log returns newest-first; scanCommits needs chronological (oldest-first) for last-write-wins
@@ -263,7 +272,7 @@ async function syncCommand(): Promise<{
   if (prNumbers.length > 0) parts.push(`pull requests [${prNumbers.map((n) => `#${n}`).join(", ")}]`);
   const attached = parts.length > 0 ? parts.join(", ") : "no new issues or pull requests";
   info(`Synced to release ${release.name} (${formatVersion(release)}): ${attached}`);
-  if (scanBase.kind === "base-ref") {
+  if (scanBase.kind === "initial-base-ref") {
     info(`Stored release baseline: ${(release.commitSha ?? currentCommit.commit).slice(0, 7)}`);
   }
 
@@ -371,22 +380,22 @@ async function getRecentReleases(): Promise<Release[]> {
 }
 
 function getScanBase(candidates: Release[], currentSha: string): ScanBase {
-  if (baseRef) {
-    const previousBaseline = assertBaseRefAllowed(candidates, currentSha, { verifyAncestorReachable });
+  if (initialBaseRef) {
+    const previousBaseline = assertInitialBaseRefAllowed(candidates, currentSha, { verifyAncestorReachable });
     let resolvedSha: string;
     try {
-      resolvedSha = resolveCommitRef(baseRef);
+      resolvedSha = resolveCommitRef(initialBaseRef);
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
-      throw new Error(`Invalid --base-ref: ${detail}`);
+      throw new Error(`Invalid --initial-base-ref: ${detail}`);
     }
-    info(`Using --base-ref ${baseRef} resolved to ${resolvedSha.slice(0, 7)}`);
+    info(`Using --initial-base-ref ${initialBaseRef} resolved to ${resolvedSha.slice(0, 7)}`);
     if (previousBaseline === "unreachable") {
-      warn("No reachable previous release baseline found; using --base-ref as the scan base");
+      warn("No reachable previous release baseline found; using --initial-base-ref as the scan base");
     } else {
-      verbose("No recent releases found; using --base-ref as the scan base");
+      verbose("No recent releases found; using --initial-base-ref as the scan base");
     }
-    return { kind: "base-ref", sha: resolvedSha, ref: baseRef };
+    return { kind: "initial-base-ref", sha: resolvedSha, ref: initialBaseRef };
   }
 
   const scanBase = selectAutomaticScanBase(candidates, currentSha, { verifyAncestorReachable });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,10 +5,16 @@ import {
   getCommitContextsBetweenShas,
   getCurrentGitInfo,
   getRepoInfo,
-  resolveFirstSyncBoundary,
+  resolveCommitRef,
   verifyAncestorReachable,
 } from "./git";
-import { findBaseSha } from "./base-sha";
+import {
+  assertBaseRefIsAncestor,
+  assertBaseRefAllowed,
+  ScanBase,
+  selectAutomaticScanBase,
+  shouldCreateReleaseForScan,
+} from "./scan-base";
 import { scanCommits } from "./scan";
 import {
   Release,
@@ -51,6 +57,7 @@ Options:
   --release-version=<version>  Release version identifier
   --stage=<stage>            Deployment stage (required for update)
   --include-paths=<paths>    Filter commits by file paths (comma-separated globs)
+  --base-ref=<ref>           One-time sync base override for initialization/migration (exclusive; scans <ref>..HEAD)
   --timeout=<seconds>        Abort if the operation exceeds this duration (default: 60)
   --json                     Output result as JSON (logs emitted as JSON Lines on stderr)
   --quiet                    Suppress info-level output (warnings and errors still printed)
@@ -67,6 +74,7 @@ Examples:
   linear-release complete
   linear-release update --stage=production
   linear-release sync --include-paths="apps/web/**,packages/**"
+  linear-release sync --base-ref=<last-released-ref> --include-paths="apps/web/**"
 `);
   process.exit(0);
 }
@@ -86,7 +94,7 @@ try {
   error(`${message} (run linear-release --help for usage)`);
   process.exit(1);
 }
-const { command, releaseName, releaseVersion, stageName, includePaths, jsonOutput, timeoutSeconds, logLevel } =
+const { command, releaseName, releaseVersion, stageName, baseRef, includePaths, jsonOutput, timeoutSeconds, logLevel } =
   parsedArgs;
 const cliWarnings = getCLIWarnings(parsedArgs);
 setLogLevel(logLevel);
@@ -165,22 +173,33 @@ async function syncCommand(): Promise<{
     throw new Error("Could not get current commit");
   }
 
-  let latestSha = await getLatestSha();
+  const recentReleases = await getRecentReleases();
+  const scanBase = getScanBase(recentReleases, currentCommit.commit);
+  let latestSha = scanBase.sha;
   let inspectingOnlyCurrentCommit = false;
 
-  try {
-    ensureCommitAvailable(latestSha);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    warn(
-      `Could not make sha ${latestSha} available in local git history; falling back to current commit only. ${message}`,
-    );
-    inspectingOnlyCurrentCommit = true;
-    latestSha = currentCommit.commit;
+  if (scanBase.kind === "base-ref") {
+    assertBaseRefIsAncestor(scanBase.ref, latestSha, currentCommit.commit, { verifyAncestorReachable });
+    const includePathSummary = effectiveIncludePaths?.length
+      ? ` with include paths: ${effectiveIncludePaths.join(", ")}`
+      : "";
+    info(`Scanning ${latestSha.slice(0, 7)}..${currentCommit.commit.slice(0, 7)}${includePathSummary}`);
+  } else {
+    try {
+      ensureCommitAvailable(latestSha);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      warn(
+        `Could not make sha ${latestSha} available in local git history; falling back to current commit only. ${message}`,
+      );
+      inspectingOnlyCurrentCommit = true;
+      latestSha = currentCommit.commit;
+    }
   }
 
   const commits = getCommitContextsBetweenShas(latestSha, currentCommit.commit, {
     includePaths: effectiveIncludePaths,
+    inspectSingleCommit: scanBase.kind !== "base-ref",
   });
 
   if (inspectingOnlyCurrentCommit) {
@@ -195,7 +214,9 @@ async function syncCommand(): Promise<{
     }
   } else {
     const commitNoun = effectiveIncludePaths?.length ? "matching commit" : "commit";
-    if (latestSha === currentCommit.commit) {
+    if (scanBase.kind === "base-ref") {
+      info(`Found ${commits.length} ${pluralize(commits.length, commitNoun)} in requested range`);
+    } else if (latestSha === currentCommit.commit) {
       info(
         `Inspected current commit ${currentCommit.commit.slice(0, 7)}; found ${commits.length} ${pluralize(commits.length, commitNoun)}`,
       );
@@ -207,14 +228,16 @@ async function syncCommand(): Promise<{
   }
 
   if (commits.length === 0) {
-    if (effectiveIncludePaths?.length) {
-      info(
-        `No matching commits found for include paths: ${effectiveIncludePaths.join(", ")}. Skipping release creation.`,
-      );
-    } else {
-      info("No commits found in the computed range. Skipping release creation.");
+    const reason = effectiveIncludePaths?.length
+      ? `No matching commits found for include paths: ${effectiveIncludePaths.join(", ")}`
+      : scanBase.kind === "base-ref"
+        ? "No commits found in the requested range"
+        : "No commits found in the computed range";
+    if (!shouldCreateReleaseForScan(commits.length, scanBase)) {
+      info(`${reason}. Skipping release creation.`);
+      return null;
     }
-    return null;
+    info(`${reason}. Syncing release anyway because --base-ref was provided to establish the baseline.`);
   }
 
   // git log returns newest-first; scanCommits needs chronological (oldest-first) for last-write-wins
@@ -240,6 +263,9 @@ async function syncCommand(): Promise<{
   if (prNumbers.length > 0) parts.push(`pull requests [${prNumbers.map((n) => `#${n}`).join(", ")}]`);
   const attached = parts.length > 0 ? parts.join(", ") : "no new issues or pull requests";
   info(`Synced to release ${release.name} (${formatVersion(release)}): ${attached}`);
+  if (scanBase.kind === "base-ref") {
+    info(`Stored release baseline: ${(release.commitSha ?? currentCommit.commit).slice(0, 7)}`);
+  }
 
   return {
     release: {
@@ -344,19 +370,31 @@ async function getRecentReleases(): Promise<Release[]> {
   return response.data.recentReleasesByAccessKey;
 }
 
-async function getLatestSha(): Promise<string> {
-  const currentSha = getCurrentGitInfo().commit;
-  if (!currentSha) {
-    throw new Error("Could not get current commit");
+function getScanBase(candidates: Release[], currentSha: string): ScanBase {
+  if (baseRef) {
+    const previousBaseline = assertBaseRefAllowed(candidates, currentSha, { verifyAncestorReachable });
+    let resolvedSha: string;
+    try {
+      resolvedSha = resolveCommitRef(baseRef);
+    } catch (e) {
+      const detail = e instanceof Error ? e.message : String(e);
+      throw new Error(`Invalid --base-ref: ${detail}`);
+    }
+    info(`Using --base-ref ${baseRef} resolved to ${resolvedSha.slice(0, 7)}`);
+    if (previousBaseline === "unreachable") {
+      warn("No reachable previous release baseline found; using --base-ref as the scan base");
+    } else {
+      verbose("No recent releases found; using --base-ref as the scan base");
+    }
+    return { kind: "base-ref", sha: resolvedSha, ref: baseRef };
   }
 
-  const candidates = await getRecentReleases();
-  const result = findBaseSha(candidates, currentSha, { verifyAncestorReachable });
-  if (result.kind === "found") {
-    return result.sha;
+  const scanBase = selectAutomaticScanBase(candidates, currentSha, { verifyAncestorReachable });
+  if (scanBase.kind !== "first-sync") {
+    return scanBase;
   }
 
-  if (candidates.length === 0) {
+  if (scanBase.candidatesConsidered === 0) {
     verbose("No recent releases found; assuming first sync");
   } else {
     // The candidate list came back non-empty but no entry is reachable from
@@ -368,20 +406,20 @@ async function getLatestSha(): Promise<string> {
     // resolveFirstSyncBoundary, which uses HEAD^1 when HEAD is a merge commit.
     // The follow-up verbose lines below print the boundary that was chosen.
     warn(
-      `No recent release is an ancestor of ${currentSha} (${candidates.length} candidate${
-        candidates.length === 1 ? "" : "s"
-      } considered); falling back to the first-sync scan boundary`,
+      `No recent release is an ancestor of ${currentSha} (${scanBase.candidatesConsidered} ${pluralize(
+        scanBase.candidatesConsidered,
+        "candidate",
+      )} considered); falling back to the first-sync scan boundary`,
     );
   }
   // For a merge HEAD the issue keys live on HEAD^2's branch, not on HEAD
   // itself, so HEAD-only would miss them. Non-merge HEAD carries its own key.
-  const boundary = resolveFirstSyncBoundary(currentSha);
-  if (boundary !== currentSha) {
-    verbose(`Merge HEAD: using HEAD^1 (${boundary}) as the scan boundary`);
+  if (scanBase.sha !== currentSha) {
+    verbose(`Merge HEAD: using HEAD^1 (${scanBase.sha}) as the scan boundary`);
   } else {
     verbose("Inspecting current commit only");
   }
-  return boundary;
+  return scanBase;
 }
 
 async function getPipelineSettings(): Promise<{

--- a/src/scan-base.test.ts
+++ b/src/scan-base.test.ts
@@ -5,13 +5,11 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getCommitContextsBetweenShas, resolveCommitRef, verifyAncestorReachable } from "./git";
 import {
-  assertInitialBaseRefIsAncestor,
-  assertInitialBaseRefAllowed,
+  assertBaseRefIsAncestor,
   type ScanBase,
   selectAutomaticScanBase,
   shouldCreateReleaseForScan,
 } from "./scan-base";
-import type { Release } from "./types";
 
 function runGit(args: string[], cwd: string): string {
   return execFileSync("git", args, {
@@ -27,15 +25,6 @@ function commit(cwd: string, file: string, content: string, message: string): st
   runGit(["add", "."], cwd);
   runGit(["commit", "-m", message], cwd);
   return runGit(["rev-parse", "HEAD"], cwd);
-}
-
-function release(name: string, commitSha: string): Release {
-  return {
-    id: `release-${name}`,
-    name,
-    commitSha,
-    createdAt: new Date().toISOString(),
-  };
 }
 
 function createMigrationRepo() {
@@ -58,6 +47,32 @@ function createMigrationRepo() {
   return { cwd, commits: { root, api1, web, api2, head, stale } };
 }
 
+function createGitFlowHotfixRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), "linear-release-gitflow-hotfix-"));
+  runGit(["init", "-q", "-b", "develop"], cwd);
+  runGit(["config", "user.email", "test@example.com"], cwd);
+  runGit(["config", "user.name", "Test User"], cwd);
+
+  commit(cwd, "app.txt", "base", "base before release/3.34.0");
+  runGit(["checkout", "-q", "-b", "release/3.34.0"], cwd);
+  const previousRelease = commit(cwd, "release.txt", "3.34.0", "release v3.34.0");
+  runGit(["tag", "v3.34.0"], cwd);
+
+  runGit(["checkout", "-q", "develop"], cwd);
+  commit(cwd, "foo/1.txt", "FOO-1", "[FOO-1] feature on develop");
+  commit(cwd, "foo/2.txt", "FOO-2", "[FOO-2] feature on develop");
+  commit(cwd, "foo/3.txt", "FOO-3", "[FOO-3] feature on develop");
+  commit(cwd, "foo/4.txt", "FOO-4", "[FOO-4] feature on develop");
+  runGit(["merge", "-q", "--no-ff", "release/3.34.0", "-m", "Merge release/3.34.0 back into develop"], cwd);
+  const forkPoint = runGit(["rev-parse", "HEAD"], cwd);
+
+  runGit(["checkout", "-q", "-b", "release/3.34.1"], cwd);
+  const head = commit(cwd, "hotfix.txt", "fix", "[HOT-1] hotfix commit");
+  runGit(["tag", "v3.34.1"], cwd);
+
+  return { cwd, commits: { previousRelease, forkPoint, head } };
+}
+
 describe("scan base selection", () => {
   let repo: ReturnType<typeof createMigrationRepo>;
   const deps = {
@@ -72,28 +87,12 @@ describe("scan base selection", () => {
     rmSync(repo.cwd, { recursive: true, force: true });
   });
 
-  it("rejects --initial-base-ref when a reachable release baseline already exists", () => {
-    expect(() => assertInitialBaseRefAllowed([release("1.0.0", repo.commits.api1)], repo.commits.head, deps)).toThrow(
-      "already has a reachable release baseline",
-    );
-  });
-
-  it("allows --initial-base-ref when previous release baselines are unreachable", () => {
-    expect(assertInitialBaseRefAllowed([release("legacy", repo.commits.stale)], repo.commits.head, deps)).toBe(
-      "unreachable",
-    );
-  });
-
-  it("allows --initial-base-ref when no previous release baseline exists", () => {
-    expect(assertInitialBaseRefAllowed([], repo.commits.head, deps)).toBe("none");
-  });
-
   it("resolves git refs to commit SHAs", () => {
     expect(resolveCommitRef("api-start", repo.cwd)).toBe(repo.commits.api1);
     expect(resolveCommitRef("main~1", repo.cwd)).toBe(repo.commits.web);
   });
 
-  it("uses --initial-base-ref as an exclusive scan base with include paths", () => {
+  it("uses --base-ref as an exclusive scan base with include paths", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
       includePaths: ["apps/api/**"],
       cwd: repo.cwd,
@@ -110,7 +109,7 @@ describe("scan base selection", () => {
     expect(commits.map((c) => c.sha)).toEqual([repo.commits.api2, repo.commits.web, repo.commits.api1]);
   });
 
-  it("treats --initial-base-ref equal to HEAD as an empty range", () => {
+  it("treats --base-ref equal to HEAD as an empty range", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.head, repo.commits.head, {
       includePaths: ["apps/api/**"],
       inspectSingleCommit: false,
@@ -120,12 +119,12 @@ describe("scan base selection", () => {
     expect(commits).toEqual([]);
   });
 
-  it("still creates a release for an accepted --initial-base-ref scan with zero matching commits", () => {
+  it("still creates a release for an accepted --base-ref scan with zero matching commits", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
       includePaths: ["does-not-match/**"],
       cwd: repo.cwd,
     });
-    const scanBase: ScanBase = { kind: "initial-base-ref", sha: repo.commits.api1, ref: "api-start" };
+    const scanBase: ScanBase = { kind: "base-ref", sha: repo.commits.api1, ref: "api-start" };
 
     expect(commits).toEqual([]);
     expect(shouldCreateReleaseForScan(commits.length, scanBase)).toBe(true);
@@ -140,9 +139,60 @@ describe("scan base selection", () => {
     expect(() => resolveCommitRef("missing-ref", repo.cwd)).toThrow('Could not resolve "missing-ref"');
   });
 
-  it("fails clearly when --initial-base-ref resolves outside the current branch history", () => {
-    expect(() => assertInitialBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
+  it("fails clearly when --base-ref resolves outside the current branch history", () => {
+    expect(() => assertBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
       "is not an ancestor of HEAD",
     );
+  });
+
+  it("supports GitFlow hotfix releases by letting --base-ref use the integration fork point", () => {
+    const gitFlowRepo = createGitFlowHotfixRepo();
+    const gitFlowDeps = {
+      verifyAncestorReachable: (sha: string, headSha: string) => verifyAncestorReachable(sha, headSha, gitFlowRepo.cwd),
+    };
+
+    try {
+      const automaticBase = selectAutomaticScanBase(
+        [
+          {
+            id: "previous",
+            name: "v3.34.0",
+            createdAt: new Date().toISOString(),
+            commitSha: gitFlowRepo.commits.previousRelease,
+          },
+        ],
+        gitFlowRepo.commits.head,
+        gitFlowDeps,
+        gitFlowRepo.cwd,
+      );
+
+      expect(automaticBase).toEqual({ kind: "release", sha: gitFlowRepo.commits.previousRelease });
+      expect(
+        getCommitContextsBetweenShas(automaticBase.sha, gitFlowRepo.commits.head, { cwd: gitFlowRepo.cwd }).map(
+          (c) => c.message?.split("\n")[0],
+        ),
+      ).toEqual([
+        "[HOT-1] hotfix commit",
+        "Merge release/3.34.0 back into develop",
+        "[FOO-4] feature on develop",
+        "[FOO-3] feature on develop",
+        "[FOO-2] feature on develop",
+        "[FOO-1] feature on develop",
+      ]);
+
+      const baseRef = runGit(["merge-base", "develop", "HEAD"], gitFlowRepo.cwd);
+      expect(baseRef).toBe(gitFlowRepo.commits.forkPoint);
+      expect(() =>
+        assertBaseRefIsAncestor("$(git merge-base develop HEAD)", baseRef, gitFlowRepo.commits.head, gitFlowDeps),
+      ).not.toThrow();
+      expect(
+        getCommitContextsBetweenShas(baseRef, gitFlowRepo.commits.head, {
+          inspectSingleCommit: false,
+          cwd: gitFlowRepo.cwd,
+        }).map((c) => c.message?.split("\n")[0]),
+      ).toEqual(["[HOT-1] hotfix commit"]);
+    } finally {
+      rmSync(gitFlowRepo.cwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/scan-base.test.ts
+++ b/src/scan-base.test.ts
@@ -139,6 +139,34 @@ describe("scan base selection", () => {
     expect(() => resolveCommitRef("missing-ref", repo.cwd)).toThrow('Could not resolve "missing-ref"');
   });
 
+  it("fetches a tag from origin when it is missing from a shallow clone", () => {
+    const remote = mkdtempSync(join(tmpdir(), "linear-release-shallow-remote-"));
+    runGit(["init", "-q", "-b", "main"], remote);
+    runGit(["config", "user.email", "test@example.com"], remote);
+    runGit(["config", "user.name", "Test User"], remote);
+    const tagged = commit(remote, "old.txt", "old", "tagged commit");
+    runGit(["tag", "v9.9.9"], remote);
+    commit(remote, "new1.txt", "new1", "after tag 1");
+    commit(remote, "new2.txt", "new2", "after tag 2");
+
+    const shallow = mkdtempSync(join(tmpdir(), "linear-release-shallow-clone-"));
+    runGit(["clone", "-q", "--depth", "1", "--single-branch", `file://${remote}`, shallow], tmpdir());
+
+    try {
+      expect(() =>
+        execFileSync("git", ["rev-parse", "--verify", "v9.9.9^{commit}"], {
+          cwd: shallow,
+          stdio: ["ignore", "pipe", "ignore"],
+        }),
+      ).toThrow();
+
+      expect(resolveCommitRef("v9.9.9", shallow)).toBe(tagged);
+    } finally {
+      rmSync(remote, { recursive: true, force: true });
+      rmSync(shallow, { recursive: true, force: true });
+    }
+  });
+
   it("fails clearly when --base-ref resolves outside the current branch history", () => {
     expect(() => assertBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
       "is not an ancestor of HEAD",

--- a/src/scan-base.test.ts
+++ b/src/scan-base.test.ts
@@ -5,8 +5,8 @@ import { join } from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { getCommitContextsBetweenShas, resolveCommitRef, verifyAncestorReachable } from "./git";
 import {
-  assertBaseRefIsAncestor,
-  assertBaseRefAllowed,
+  assertInitialBaseRefIsAncestor,
+  assertInitialBaseRefAllowed,
   type ScanBase,
   selectAutomaticScanBase,
   shouldCreateReleaseForScan,
@@ -72,18 +72,20 @@ describe("scan base selection", () => {
     rmSync(repo.cwd, { recursive: true, force: true });
   });
 
-  it("rejects --base-ref when a reachable release baseline already exists", () => {
-    expect(() => assertBaseRefAllowed([release("1.0.0", repo.commits.api1)], repo.commits.head, deps)).toThrow(
+  it("rejects --initial-base-ref when a reachable release baseline already exists", () => {
+    expect(() => assertInitialBaseRefAllowed([release("1.0.0", repo.commits.api1)], repo.commits.head, deps)).toThrow(
       "already has a reachable release baseline",
     );
   });
 
-  it("allows --base-ref when previous release baselines are unreachable", () => {
-    expect(assertBaseRefAllowed([release("legacy", repo.commits.stale)], repo.commits.head, deps)).toBe("unreachable");
+  it("allows --initial-base-ref when previous release baselines are unreachable", () => {
+    expect(assertInitialBaseRefAllowed([release("legacy", repo.commits.stale)], repo.commits.head, deps)).toBe(
+      "unreachable",
+    );
   });
 
-  it("allows --base-ref when no previous release baseline exists", () => {
-    expect(assertBaseRefAllowed([], repo.commits.head, deps)).toBe("none");
+  it("allows --initial-base-ref when no previous release baseline exists", () => {
+    expect(assertInitialBaseRefAllowed([], repo.commits.head, deps)).toBe("none");
   });
 
   it("resolves git refs to commit SHAs", () => {
@@ -91,7 +93,7 @@ describe("scan base selection", () => {
     expect(resolveCommitRef("main~1", repo.cwd)).toBe(repo.commits.web);
   });
 
-  it("uses --base-ref as an exclusive scan base with include paths", () => {
+  it("uses --initial-base-ref as an exclusive scan base with include paths", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
       includePaths: ["apps/api/**"],
       cwd: repo.cwd,
@@ -108,7 +110,7 @@ describe("scan base selection", () => {
     expect(commits.map((c) => c.sha)).toEqual([repo.commits.api2, repo.commits.web, repo.commits.api1]);
   });
 
-  it("treats --base-ref equal to HEAD as an empty range", () => {
+  it("treats --initial-base-ref equal to HEAD as an empty range", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.head, repo.commits.head, {
       includePaths: ["apps/api/**"],
       inspectSingleCommit: false,
@@ -118,12 +120,12 @@ describe("scan base selection", () => {
     expect(commits).toEqual([]);
   });
 
-  it("still creates a release for an accepted --base-ref scan with zero matching commits", () => {
+  it("still creates a release for an accepted --initial-base-ref scan with zero matching commits", () => {
     const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
       includePaths: ["does-not-match/**"],
       cwd: repo.cwd,
     });
-    const scanBase: ScanBase = { kind: "base-ref", sha: repo.commits.api1, ref: "api-start" };
+    const scanBase: ScanBase = { kind: "initial-base-ref", sha: repo.commits.api1, ref: "api-start" };
 
     expect(commits).toEqual([]);
     expect(shouldCreateReleaseForScan(commits.length, scanBase)).toBe(true);
@@ -138,8 +140,8 @@ describe("scan base selection", () => {
     expect(() => resolveCommitRef("missing-ref", repo.cwd)).toThrow('Could not resolve "missing-ref"');
   });
 
-  it("fails clearly when --base-ref resolves outside the current branch history", () => {
-    expect(() => assertBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
+  it("fails clearly when --initial-base-ref resolves outside the current branch history", () => {
+    expect(() => assertInitialBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
       "is not an ancestor of HEAD",
     );
   });

--- a/src/scan-base.test.ts
+++ b/src/scan-base.test.ts
@@ -1,0 +1,146 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { getCommitContextsBetweenShas, resolveCommitRef, verifyAncestorReachable } from "./git";
+import {
+  assertBaseRefIsAncestor,
+  assertBaseRefAllowed,
+  type ScanBase,
+  selectAutomaticScanBase,
+  shouldCreateReleaseForScan,
+} from "./scan-base";
+import type { Release } from "./types";
+
+function runGit(args: string[], cwd: string): string {
+  return execFileSync("git", args, {
+    cwd,
+    stdio: ["ignore", "pipe", "ignore"],
+    encoding: "utf8",
+  }).trim();
+}
+
+function commit(cwd: string, file: string, content: string, message: string): string {
+  mkdirSync(join(cwd, file, ".."), { recursive: true });
+  writeFileSync(join(cwd, file), content);
+  runGit(["add", "."], cwd);
+  runGit(["commit", "-m", message], cwd);
+  return runGit(["rev-parse", "HEAD"], cwd);
+}
+
+function release(name: string, commitSha: string): Release {
+  return {
+    id: `release-${name}`,
+    name,
+    commitSha,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+function createMigrationRepo() {
+  const cwd = mkdtempSync(join(tmpdir(), "linear-release-scan-base-"));
+  runGit(["init", "-q", "-b", "main"], cwd);
+  runGit(["config", "user.email", "test@example.com"], cwd);
+  runGit(["config", "user.name", "Test User"], cwd);
+
+  const root = commit(cwd, "README.md", "root", "root");
+  const api1 = commit(cwd, "apps/api/a.txt", "api 1", "LIN-100 api one");
+  runGit(["tag", "api-start"], cwd);
+  const web = commit(cwd, "apps/web/a.txt", "web", "LIN-200 web");
+  const api2 = commit(cwd, "apps/api/b.txt", "api 2", "LIN-300 api two");
+  const head = runGit(["rev-parse", "HEAD"], cwd);
+
+  runGit(["checkout", "-q", "-b", "stale", root], cwd);
+  const stale = commit(cwd, "legacy/service.txt", "legacy", "legacy release");
+  runGit(["checkout", "-q", "main"], cwd);
+
+  return { cwd, commits: { root, api1, web, api2, head, stale } };
+}
+
+describe("scan base selection", () => {
+  let repo: ReturnType<typeof createMigrationRepo>;
+  const deps = {
+    verifyAncestorReachable: (sha: string, headSha: string) => verifyAncestorReachable(sha, headSha, repo.cwd),
+  };
+
+  beforeAll(() => {
+    repo = createMigrationRepo();
+  });
+
+  afterAll(() => {
+    rmSync(repo.cwd, { recursive: true, force: true });
+  });
+
+  it("rejects --base-ref when a reachable release baseline already exists", () => {
+    expect(() => assertBaseRefAllowed([release("1.0.0", repo.commits.api1)], repo.commits.head, deps)).toThrow(
+      "already has a reachable release baseline",
+    );
+  });
+
+  it("allows --base-ref when previous release baselines are unreachable", () => {
+    expect(assertBaseRefAllowed([release("legacy", repo.commits.stale)], repo.commits.head, deps)).toBe("unreachable");
+  });
+
+  it("allows --base-ref when no previous release baseline exists", () => {
+    expect(assertBaseRefAllowed([], repo.commits.head, deps)).toBe("none");
+  });
+
+  it("resolves git refs to commit SHAs", () => {
+    expect(resolveCommitRef("api-start", repo.cwd)).toBe(repo.commits.api1);
+    expect(resolveCommitRef("main~1", repo.cwd)).toBe(repo.commits.web);
+  });
+
+  it("uses --base-ref as an exclusive scan base with include paths", () => {
+    const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
+      includePaths: ["apps/api/**"],
+      cwd: repo.cwd,
+    });
+
+    expect(commits.map((c) => c.sha)).toEqual([repo.commits.api2]);
+  });
+
+  it("allows the root commit as an exclusive scan base", () => {
+    const commits = getCommitContextsBetweenShas(repo.commits.root, repo.commits.head, {
+      cwd: repo.cwd,
+    });
+
+    expect(commits.map((c) => c.sha)).toEqual([repo.commits.api2, repo.commits.web, repo.commits.api1]);
+  });
+
+  it("treats --base-ref equal to HEAD as an empty range", () => {
+    const commits = getCommitContextsBetweenShas(repo.commits.head, repo.commits.head, {
+      includePaths: ["apps/api/**"],
+      inspectSingleCommit: false,
+      cwd: repo.cwd,
+    });
+
+    expect(commits).toEqual([]);
+  });
+
+  it("still creates a release for an accepted --base-ref scan with zero matching commits", () => {
+    const commits = getCommitContextsBetweenShas(repo.commits.api1, repo.commits.head, {
+      includePaths: ["does-not-match/**"],
+      cwd: repo.cwd,
+    });
+    const scanBase: ScanBase = { kind: "base-ref", sha: repo.commits.api1, ref: "api-start" };
+
+    expect(commits).toEqual([]);
+    expect(shouldCreateReleaseForScan(commits.length, scanBase)).toBe(true);
+  });
+
+  it("keeps normal automatic scans from creating releases with zero commits", () => {
+    const scanBase = selectAutomaticScanBase([], repo.commits.head, deps, repo.cwd);
+    expect(shouldCreateReleaseForScan(0, scanBase)).toBe(false);
+  });
+
+  it("fails clearly for refs that do not resolve to a commit", () => {
+    expect(() => resolveCommitRef("missing-ref", repo.cwd)).toThrow('Could not resolve "missing-ref"');
+  });
+
+  it("fails clearly when --base-ref resolves outside the current branch history", () => {
+    expect(() => assertBaseRefIsAncestor("stale", repo.commits.stale, repo.commits.head, deps)).toThrow(
+      "is not an ancestor of HEAD",
+    );
+  });
+});

--- a/src/scan-base.ts
+++ b/src/scan-base.ts
@@ -1,0 +1,66 @@
+import { findBaseSha, FindBaseShaDeps } from "./base-sha";
+import { resolveFirstSyncBoundary } from "./git";
+import type { Release } from "./types";
+
+export type ScanBase =
+  | { kind: "release"; sha: string }
+  | { kind: "first-sync"; sha: string; candidatesConsidered: number }
+  | { kind: "base-ref"; sha: string; ref: string };
+
+export function selectAutomaticScanBase(
+  candidates: Release[],
+  currentSha: string,
+  deps: FindBaseShaDeps,
+  cwd: string = process.cwd(),
+): ScanBase {
+  const result = findBaseSha(candidates, currentSha, deps);
+  if (result.kind === "found") {
+    return { kind: "release", sha: result.sha };
+  }
+
+  return {
+    kind: "first-sync",
+    sha: resolveFirstSyncBoundary(currentSha, cwd),
+    candidatesConsidered: candidates.length,
+  };
+}
+
+export function assertBaseRefAllowed(
+  candidates: Release[],
+  currentSha: string,
+  deps: FindBaseShaDeps,
+): "none" | "unreachable" {
+  const result = findBaseSha(candidates, currentSha, deps);
+  if (result.kind === "found") {
+    throw new Error(
+      `--base-ref is only for initialization or migration. This pipeline already has a reachable release baseline at ${result.sha.slice(
+        0,
+        7,
+      )}. Remove --base-ref to use the normal range.`,
+    );
+  }
+
+  return candidates.length === 0 ? "none" : "unreachable";
+}
+
+export function assertBaseRefIsAncestor(
+  baseRef: string,
+  resolvedSha: string,
+  currentSha: string,
+  deps: FindBaseShaDeps,
+): void {
+  if (deps.verifyAncestorReachable(resolvedSha, currentSha)) {
+    return;
+  }
+
+  throw new Error(
+    `--base-ref ${baseRef} (${resolvedSha.slice(0, 7)}) is not an ancestor of HEAD ${currentSha.slice(
+      0,
+      7,
+    )}. Choose a ref on the current branch history.`,
+  );
+}
+
+export function shouldCreateReleaseForScan(commitsLength: number, scanBase: ScanBase): boolean {
+  return commitsLength > 0 || scanBase.kind === "base-ref";
+}

--- a/src/scan-base.ts
+++ b/src/scan-base.ts
@@ -5,7 +5,7 @@ import type { Release } from "./types";
 export type ScanBase =
   | { kind: "release"; sha: string }
   | { kind: "first-sync"; sha: string; candidatesConsidered: number }
-  | { kind: "initial-base-ref"; sha: string; ref: string };
+  | { kind: "base-ref"; sha: string; ref: string };
 
 export function selectAutomaticScanBase(
   candidates: Release[],
@@ -25,26 +25,8 @@ export function selectAutomaticScanBase(
   };
 }
 
-export function assertInitialBaseRefAllowed(
-  candidates: Release[],
-  currentSha: string,
-  deps: FindBaseShaDeps,
-): "none" | "unreachable" {
-  const result = findBaseSha(candidates, currentSha, deps);
-  if (result.kind === "found") {
-    throw new Error(
-      `--initial-base-ref is only for initialization or migration. This pipeline already has a reachable release baseline at ${result.sha.slice(
-        0,
-        7,
-      )}. Remove --initial-base-ref to use the normal range.`,
-    );
-  }
-
-  return candidates.length === 0 ? "none" : "unreachable";
-}
-
-export function assertInitialBaseRefIsAncestor(
-  initialBaseRef: string,
+export function assertBaseRefIsAncestor(
+  baseRef: string,
   resolvedSha: string,
   currentSha: string,
   deps: FindBaseShaDeps,
@@ -54,7 +36,7 @@ export function assertInitialBaseRefIsAncestor(
   }
 
   throw new Error(
-    `--initial-base-ref ${initialBaseRef} (${resolvedSha.slice(0, 7)}) is not an ancestor of HEAD ${currentSha.slice(
+    `--base-ref ${baseRef} (${resolvedSha.slice(0, 7)}) is not an ancestor of HEAD ${currentSha.slice(
       0,
       7,
     )}. Choose a ref on the current branch history.`,
@@ -62,5 +44,5 @@ export function assertInitialBaseRefIsAncestor(
 }
 
 export function shouldCreateReleaseForScan(commitsLength: number, scanBase: ScanBase): boolean {
-  return commitsLength > 0 || scanBase.kind === "initial-base-ref";
+  return commitsLength > 0 || scanBase.kind === "base-ref";
 }

--- a/src/scan-base.ts
+++ b/src/scan-base.ts
@@ -5,7 +5,7 @@ import type { Release } from "./types";
 export type ScanBase =
   | { kind: "release"; sha: string }
   | { kind: "first-sync"; sha: string; candidatesConsidered: number }
-  | { kind: "base-ref"; sha: string; ref: string };
+  | { kind: "initial-base-ref"; sha: string; ref: string };
 
 export function selectAutomaticScanBase(
   candidates: Release[],
@@ -25,7 +25,7 @@ export function selectAutomaticScanBase(
   };
 }
 
-export function assertBaseRefAllowed(
+export function assertInitialBaseRefAllowed(
   candidates: Release[],
   currentSha: string,
   deps: FindBaseShaDeps,
@@ -33,18 +33,18 @@ export function assertBaseRefAllowed(
   const result = findBaseSha(candidates, currentSha, deps);
   if (result.kind === "found") {
     throw new Error(
-      `--base-ref is only for initialization or migration. This pipeline already has a reachable release baseline at ${result.sha.slice(
+      `--initial-base-ref is only for initialization or migration. This pipeline already has a reachable release baseline at ${result.sha.slice(
         0,
         7,
-      )}. Remove --base-ref to use the normal range.`,
+      )}. Remove --initial-base-ref to use the normal range.`,
     );
   }
 
   return candidates.length === 0 ? "none" : "unreachable";
 }
 
-export function assertBaseRefIsAncestor(
-  baseRef: string,
+export function assertInitialBaseRefIsAncestor(
+  initialBaseRef: string,
   resolvedSha: string,
   currentSha: string,
   deps: FindBaseShaDeps,
@@ -54,7 +54,7 @@ export function assertBaseRefIsAncestor(
   }
 
   throw new Error(
-    `--base-ref ${baseRef} (${resolvedSha.slice(0, 7)}) is not an ancestor of HEAD ${currentSha.slice(
+    `--initial-base-ref ${initialBaseRef} (${resolvedSha.slice(0, 7)}) is not an ancestor of HEAD ${currentSha.slice(
       0,
       7,
     )}. Choose a ref on the current branch history.`,
@@ -62,5 +62,5 @@ export function assertBaseRefIsAncestor(
 }
 
 export function shouldCreateReleaseForScan(commitsLength: number, scanBase: ScanBase): boolean {
-  return commitsLength > 0 || scanBase.kind === "base-ref";
+  return commitsLength > 0 || scanBase.kind === "initial-base-ref";
 }


### PR DESCRIPTION
`--base-ref` scans `<ref>..HEAD`, applies existing path filters, and stores `HEAD` as the new release baseline.

When provided, it skips automatic release baseline selection for that run. This covers the original first-sync use cases, where no useful prior release `commitSha` exists yet, and also workflows where the desired lower bound is not a prior release `commitSha`, such as hotfix branches whose release delta should start at the fork point from an integration branch.

Usage examples:

First-time monorepo onboarding:

```bash
linear-release sync --base-ref=<commit-before-backfill> --include-paths="apps/api/**"
```

Rewritten repo migration:

```bash
linear-release sync --base-ref=<new-repo-baseline> --include-paths="apps/api/**"
```

Hotfix branch delta:

```bash
linear-release sync --base-ref="$(git merge-base origin/develop HEAD)"
```

`--base-ref` is advanced range control: the ref must be an ancestor of `HEAD`, and users intentionally own the selected range.

---

Fixes https://github.com/linear/linear-release/issues/88.