### PR TITLE
Fix CLI_VERSION ReferenceError in pnpm dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,16 +26,15 @@ import { error, info, setJsonMode, setLogLevel, setStderr, verbose, warn } from 
 import { pluralize } from "./util";
 import { buildUserAgent } from "./user-agent";
 import { withRetry } from "./retry";
-
-declare const CLI_VERSION: string;
+import { getCliVersion } from "./version";
 
 if (process.argv.includes("--version") || process.argv.includes("-v")) {
-  console.log(CLI_VERSION);
+  console.log(getCliVersion());
   process.exit(0);
 }
 
 if (process.argv.includes("--help") || process.argv.includes("-h")) {
-  console.log(`Linear Release CLI v${CLI_VERSION}
+  console.log(`Linear Release CLI v${getCliVersion()}
 
 Integrate CI/CD pipelines with Linear releases.
 
@@ -102,7 +101,7 @@ function formatVersion(release: { version?: string } | null | undefined): string
 }
 
 const logEnvironmentSummary = () => {
-  info(`linear-release v${CLI_VERSION}`);
+  info(`linear-release v${getCliVersion()}`);
   if (releaseName) {
     info(`Using custom release name: ${releaseName}`);
   }


### PR DESCRIPTION
`CLI_VERSION` is only injected by `bun build --define`, so `pnpm dev` (which runs via `node --import=tsx`) crashed with `ReferenceError: CLI_VERSION is not defined`. Replaced the raw global references in `src/index.ts` with the existing `getCliVersion()` helper from `src/version.ts`, which falls back to `"dev"` when the define isn't present.

Verified: `pnpm dev --version` now prints `dev` instead of crashing.