### PR TITLE
Set maxBuffer on runLog to avoid ENOBUFS on large commit ranges

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -382,11 +382,16 @@ export function ensureCommitAvailable(sha: string, cwd: string = process.cwd()):
   );
 }
 
+// A wide commit range outgrows Node's 1 MB default; keep a finite ceiling
+// rather than Infinity to bound memory.
+const RUN_LOG_MAX_BUFFER = 256 * 1024 * 1024;
+
 function runLog(rangeArgs: string, cwd: string): CommitContext[] {
   const output = execSync(`git log --format=%H%x1f%B%x1f%D%x1e ${rangeArgs}`, {
     cwd,
     stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
+    maxBuffer: RUN_LOG_MAX_BUFFER,
   });
   return output
     .split("\x1e")


### PR DESCRIPTION
Fixes LIN-72561. `runLog` ran `git log` via `execSync` with no `maxBuffer`, inheriting Node's 1 MB default — wide ranges with full commit bodies threw `spawnSync /bin/sh ENOBUFS` and aborted the sync. Caps at a finite 256 MB (bounded, not Infinity). Fixes both the range read and the silently-dropped single-commit path, since both go through `runLog`.