### PR TITLE
Add --released-at flag to set release date from the CLI

### DIFF
--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -399,6 +399,26 @@ describe("parseCLIArgs", () => {
     expect(() => parseCLIArgs(["--timeout=-5"])).toThrow('Invalid --timeout value: "-5"');
   });
 
+  it("defaults --released-at to undefined", () => {
+    const result = parseCLIArgs([]);
+    expect(result.releasedAt).toBeUndefined();
+  });
+
+  it("parses a valid ISO-8601 --released-at to a Date", () => {
+    const result = parseCLIArgs(["--released-at", "2026-07-04T18:00:00Z"]);
+    expect(result.releasedAt).toBeInstanceOf(Date);
+    expect(result.releasedAt?.toISOString()).toBe("2026-07-04T18:00:00.000Z");
+  });
+
+  it("parses --released-at with = syntax", () => {
+    const result = parseCLIArgs(["--released-at=2026-01-15T09:30:00Z"]);
+    expect(result.releasedAt?.toISOString()).toBe("2026-01-15T09:30:00.000Z");
+  });
+
+  it("throws a helpful error on invalid --released-at value", () => {
+    expect(() => parseCLIArgs(["--released-at", "not-a-date"])).toThrow(/Invalid --released-at value/);
+  });
+
   it("defaults logLevel to Default", () => {
     const result = parseCLIArgs([]);
     expect(result.logLevel).toBe(LogLevel.Default);

--- a/src/args.ts
+++ b/src/args.ts
@@ -30,6 +30,7 @@ export type ParsedCLIArgs = {
   links: ReleaseLink[];
   documents: ReleaseDocumentSpec[];
   releaseNotes?: ReleaseNoteSpec;
+  releasedAt?: Date;
   jsonOutput: boolean;
   dryRun: boolean;
   timeoutSeconds: number;
@@ -138,6 +139,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
       "document-file": { type: "string", multiple: true },
       "release-notes": { type: "string", multiple: true },
       "release-notes-file": { type: "string", multiple: true },
+      "released-at": { type: "string" },
       json: { type: "boolean", default: false },
       "dry-run": { type: "boolean", default: false },
       timeout: { type: "string" },
@@ -178,6 +180,17 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     }
     includeSubjects = rawIncludeSubjects;
   }
+  let releasedAt: Date | undefined;
+  if (values["released-at"] !== undefined) {
+    const parsed = new Date(values["released-at"]);
+    if (isNaN(parsed.getTime())) {
+      throw new Error(
+        `Invalid --released-at value: "${values["released-at"]}". Expected an ISO-8601 date string (e.g. 2026-07-04T18:00:00Z).`,
+      );
+    }
+    releasedAt = parsed;
+  }
+
   const command = positionals[0] || "sync";
   const links = (values.link ?? []).map(parseReleaseLink);
 
@@ -229,6 +242,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     links,
     documents,
     releaseNotes,
+    releasedAt,
     jsonOutput: values.json ?? false,
     dryRun: values["dry-run"] ?? false,
     timeoutSeconds,

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,6 +65,7 @@ Options:
   --release-notes <content>  Set the release notes covering this release (last-wins)
   --release-notes-file <path> Set release notes from a file ("-" for stdin; last-wins)
   --base-ref=<ref>           Override sync scan base (exclusive; scans <ref>..HEAD)
+  --released-at=<datetime>   Set the release date as an ISO-8601 string (e.g. 2026-07-04T18:00:00Z)
   --timeout=<seconds>        Abort if the operation exceeds this duration (default: 60)
   --json                     Output result as JSON (logs emitted as JSON Lines on stderr)
   --dry-run                  Scan and call read-only Linear APIs, but skip create/update mutations
@@ -119,6 +120,7 @@ const {
   links,
   documents: documentSpecs,
   releaseNotes: releaseNotesSpec,
+  releasedAt,
   jsonOutput,
   dryRun,
   timeoutSeconds,
@@ -369,8 +371,9 @@ async function syncCommand(): Promise<{
   if (dryRun) {
     const targetName = releaseName ?? "(server-assigned)";
     const versionPart = releaseVersion ? `version: ${releaseVersion}` : "no version set";
+    const datePart = releasedAt ? `, released-at: ${releasedAt.toISOString()}` : "";
     info(
-      `[dry-run] Would sync release ${targetName} (${versionPart}): ${scanned}${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}`,
+      `[dry-run] Would sync release ${targetName} (${versionPart}): ${scanned}${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}${datePart}`,
     );
     return null;
   }
@@ -384,6 +387,7 @@ async function syncCommand(): Promise<{
     links,
     documents,
     releaseNotes,
+    releasedAt,
   );
   info(
     `Synced to release ${release.name} (${formatVersion(release)}): ${scanned}${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}`,
@@ -413,8 +417,9 @@ async function completeCommand(): Promise<{
   if (dryRun) {
     const targetName = releaseName ?? "(current release)";
     const versionPart = releaseVersion ? `version: ${releaseVersion}` : "no version set";
+    const datePart = releasedAt ? `, released-at: ${releasedAt.toISOString()}` : "";
     info(
-      `[dry-run] Would complete release ${targetName} (${versionPart})${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}`,
+      `[dry-run] Would complete release ${targetName} (${versionPart})${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}${datePart}`,
     );
     return null;
   }
@@ -426,6 +431,7 @@ async function completeCommand(): Promise<{
     links,
     documents,
     releaseNotes,
+    releasedAt,
   });
   if (result.success) {
     info(
@@ -459,8 +465,9 @@ async function updateCommand(): Promise<{
   if (dryRun) {
     const targetName = releaseName ?? "(current release)";
     const versionPart = releaseVersion ? `version: ${releaseVersion}` : "no version set";
+    const datePart = releasedAt ? `, released-at: ${releasedAt.toISOString()}` : "";
     info(
-      `[dry-run] Would update release ${targetName} (${versionPart}) to stage ${stageName}${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}`,
+      `[dry-run] Would update release ${targetName} (${versionPart}) to stage ${stageName}${formatLinkSummary(links)}${formatDocumentsSummary(documents)}${formatReleaseNotesSummary(releaseNotes)}${datePart}`,
     );
     return null;
   }
@@ -474,6 +481,7 @@ async function updateCommand(): Promise<{
       links,
       documents,
       releaseNotes,
+      releasedAt,
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error";
@@ -594,6 +602,7 @@ async function syncRelease(
   releaseLinks: ReleaseLink[],
   releaseDocuments: ReleaseDocument[],
   releaseNotesValue: ReleaseNotes | undefined,
+  releasedAt?: Date,
 ): Promise<Release> {
   const currentSha = await getCurrentGitInfo().commit;
   if (!currentSha) {
@@ -632,6 +641,7 @@ async function syncRelease(
         links: releaseLinks.length > 0 ? releaseLinks : undefined,
         documents: releaseDocuments.length > 0 ? releaseDocuments : undefined,
         releaseNotes: releaseNotesValue,
+        releasedAt: releasedAt?.toISOString(),
         pullRequestReferences: prNumbers.map((number) => ({
           repositoryOwner: owner,
           repositoryName: name,
@@ -664,6 +674,7 @@ async function completeRelease(options: {
   links: ReleaseLink[];
   documents: ReleaseDocument[];
   releaseNotes?: ReleaseNotes;
+  releasedAt?: Date;
 }): Promise<{
   success: boolean;
   release: { id: string; name: string; version?: string; url?: string } | null;
@@ -675,6 +686,7 @@ async function completeRelease(options: {
     links: releaseLinks,
     documents: releaseDocuments,
     releaseNotes: notesValue,
+    releasedAt,
   } = options;
 
   const response = await apiRequest<AccessKeyCompleteReleaseResponse>(
@@ -699,6 +711,7 @@ async function completeRelease(options: {
         links: releaseLinks.length > 0 ? releaseLinks : undefined,
         documents: releaseDocuments.length > 0 ? releaseDocuments : undefined,
         releaseNotes: notesValue,
+        releasedAt: releasedAt?.toISOString(),
       },
     },
   );
@@ -713,6 +726,7 @@ async function updateReleaseByPipeline(options: {
   links: ReleaseLink[];
   documents: ReleaseDocument[];
   releaseNotes?: ReleaseNotes;
+  releasedAt?: Date;
 }): Promise<{
   success: boolean;
   release: {
@@ -723,7 +737,15 @@ async function updateReleaseByPipeline(options: {
     stageName: string;
   } | null;
 }> {
-  const { stage, version, name, links: releaseLinks, documents: releaseDocuments, releaseNotes: notesValue } = options;
+  const {
+    stage,
+    version,
+    name,
+    links: releaseLinks,
+    documents: releaseDocuments,
+    releaseNotes: notesValue,
+    releasedAt,
+  } = options;
   const response = await apiRequest<AccessKeyUpdateByPipelineResponse>(
     `
     mutation releaseUpdateByPipelineByAccessKey($input: ReleaseUpdateByPipelineInputBase!) {
@@ -749,6 +771,7 @@ async function updateReleaseByPipeline(options: {
         links: releaseLinks.length > 0 ? releaseLinks : undefined,
         documents: releaseDocuments.length > 0 ? releaseDocuments : undefined,
         releaseNotes: notesValue,
+        releasedAt: releasedAt?.toISOString(),
       },
     },
   );


### PR DESCRIPTION
## Summary

Closes #114.

The CLI has no way to set a release's date — it always defaults to whenever
the command runs. For scheduled releases (mobile, desktop) this means the
release is dated at announce/QA time rather than the actual ship date, and
someone has to correct it by hand in the Linear UI.

This adds a `--released-at` flag accepted by `sync`, `complete`, and `update`:

```
linear-release complete --released-at=2026-07-04T18:00:00Z
linear-release sync --released-at 2026-07-04T18:00:00Z
linear-release update --stage=production --released-at 2026-07-04T18:00:00Z
```

The value is validated as a parseable date at CLI entry and forwarded to the
API as an ISO-8601 string. `--dry-run` output includes the date so it can be
verified before a live run. Invalid values produce a clear error:

```
Invalid --released-at value: "last tuesday". Expected an ISO-8601 date string (e.g. 2026-07-04T18:00:00Z).
```