### PR TITLE
Add --issue-pattern flag for custom subject-line identifier extraction

### DIFF
--- a/src/args.test.ts
+++ b/src/args.test.ts
@@ -120,6 +120,25 @@ describe("parseCLIArgs", () => {
     expect(() => parseCLIArgs(["--include-subjects", "([unclosed"])).toThrow(/Invalid --include-subjects regex/);
   });
 
+  it("defaults --issue-pattern to null", () => {
+    const result = parseCLIArgs([]);
+    expect(result.issuePattern).toBeNull();
+  });
+
+  it("returns --issue-pattern as the raw pattern string", () => {
+    const result = parseCLIArgs(["--issue-pattern", "\\[([A-Z]+-\\d+)\\]"]);
+    expect(result.issuePattern).toBe("\\[([A-Z]+-\\d+)\\]");
+  });
+
+  it("treats empty --issue-pattern as no pattern", () => {
+    const result = parseCLIArgs(["--issue-pattern", ""]);
+    expect(result.issuePattern).toBeNull();
+  });
+
+  it("throws a helpful error on invalid --issue-pattern regex", () => {
+    expect(() => parseCLIArgs(["--issue-pattern", "([unclosed"])).toThrow(/Invalid --issue-pattern regex/);
+  });
+
   it("parses repeatable --link values", () => {
     const result = parseCLIArgs([
       "sync",

--- a/src/args.ts
+++ b/src/args.ts
@@ -27,6 +27,7 @@ export type ParsedCLIArgs = {
   baseRef?: string;
   includePaths: string[];
   includeSubjects: string | null;
+  issuePattern: string | null;
   links: ReleaseLink[];
   documents: ReleaseDocumentSpec[];
   releaseNotes?: ReleaseNoteSpec;
@@ -133,6 +134,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
       "base-ref": { type: "string" },
       "include-paths": { type: "string" },
       "include-subjects": { type: "string" },
+      "issue-pattern": { type: "string" },
       link: { type: "string", multiple: true },
       document: { type: "string", multiple: true },
       "document-file": { type: "string", multiple: true },
@@ -178,6 +180,18 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
     }
     includeSubjects = rawIncludeSubjects;
   }
+  let issuePattern: string | null = null;
+  const rawIssuePattern = values["issue-pattern"];
+  if (rawIssuePattern !== undefined && rawIssuePattern.length > 0) {
+    try {
+      new RegExp(rawIssuePattern);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new Error(`Invalid --issue-pattern regex: ${detail}`);
+    }
+    issuePattern = rawIssuePattern;
+  }
+
   const command = positionals[0] || "sync";
   const links = (values.link ?? []).map(parseReleaseLink);
 
@@ -226,6 +240,7 @@ export function parseCLIArgs(argv: string[]): ParsedCLIArgs {
           .filter((p) => p.length > 0)
       : [],
     includeSubjects,
+    issuePattern,
     links,
     documents,
     releaseNotes,

--- a/src/extractors.test.ts
+++ b/src/extractors.test.ts
@@ -907,3 +907,68 @@ describe("extractPullRequestNumbersForCommit — GitLab merge request trailer", 
     expect(result).toEqual([]);
   });
 });
+
+describe("extractLinearIssueIdentifiersForCommit with --issue-pattern", () => {
+  const conventionalPattern = /\[(\w{1,7}-\d+)\]/;
+
+  it("extracts identifier from Conventional Commits bracket notation", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: null,
+      message: "feat(routing)[ENG-123]: add stop reordering",
+    };
+    const result = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: conventionalPattern });
+    expect(ids(result)).toContain("ENG-123");
+  });
+
+  it("extracts identifier when type has no scope", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: null,
+      message: "fix[ENG-456]: handle empty payload",
+    };
+    const result = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: conventionalPattern });
+    expect(ids(result)).toContain("ENG-456");
+  });
+
+  it("extracts multiple identifiers from the same subject", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: null,
+      message: "chore[ENG-7][ENG-8]: bump deps",
+    };
+    const result = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: conventionalPattern });
+    expect(ids(result)).toEqual(expect.arrayContaining(["ENG-7", "ENG-8"]));
+  });
+
+  it("does not extract when no group 1 matches a valid identifier", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: null,
+      message: "chore(deps)[notanid]: bump",
+    };
+    const result = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: conventionalPattern });
+    expect(ids(result)).toEqual([]);
+  });
+
+  it("still extracts identifiers from branch name regardless of issuePattern", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: "feature/ENG-99-my-change",
+      message: "feat[ENG-100]: do something",
+    };
+    const result = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: conventionalPattern });
+    expect(ids(result)).toEqual(expect.arrayContaining(["ENG-99", "ENG-100"]));
+  });
+
+  it("behaves identically to no pattern when issuePattern is null", () => {
+    const commit: CommitContext = {
+      sha: "abc123",
+      branchName: null,
+      message: "feat[ENG-123]: some change",
+    };
+    const withNull = extractLinearIssueIdentifiersForCommit(commit, { issuePattern: null });
+    const withUndefined = extractLinearIssueIdentifiersForCommit(commit);
+    expect(ids(withNull)).toEqual(ids(withUndefined));
+  });
+});

--- a/src/extractors.ts
+++ b/src/extractors.ts
@@ -230,7 +230,29 @@ export type ExtractedIdentifier = {
   source: "branch_name" | "commit_message";
 };
 
-export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): ExtractedIdentifier[] {
+/**
+ * Apply a user-supplied regex to the commit subject and extract any Linear
+ * issue identifiers captured in group 1. Matches anywhere in the subject so
+ * teams that embed the identifier mid-subject (e.g. Conventional Commits with
+ * `feat(scope)[ENG-123]: …`) can supply a pattern like `\[(\w+-\d+)\]`.
+ */
+function matchCustomSubjectPattern(message: string, pattern: RegExp): IdentifierMatch[] {
+  const subject = getCommitSubject(message);
+  const results: IdentifierMatch[] = [];
+  const globalPattern = new RegExp(pattern.source, pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`);
+  let match;
+  while ((match = globalPattern.exec(subject)) !== null) {
+    const captured = match[1];
+    if (!captured) continue;
+    results.push(...matchAllIdentifiers(captured));
+  }
+  return results;
+}
+
+export function extractLinearIssueIdentifiersForCommit(
+  commit: CommitContext,
+  options?: { issuePattern?: RegExp | null },
+): ExtractedIdentifier[] {
   if (!commit) {
     return [];
   }
@@ -267,7 +289,12 @@ export function extractLinearIssueIdentifiersForCommit(commit: CommitContext): E
   const scanTarget = messageDepth % 2 === 1 ? afterTitle : (commit.message ?? "");
   const message = stripSquashBlock(scanTarget);
   if (message.length > 0) {
-    for (const match of [...matchCommonSubjectPatterns(message), ...matchMagicWordIdentifiers(message)]) {
+    const customMatches = options?.issuePattern ? matchCustomSubjectPattern(message, options.issuePattern) : [];
+    for (const match of [
+      ...matchCommonSubjectPatterns(message),
+      ...matchMagicWordIdentifiers(message),
+      ...customMatches,
+    ]) {
       if (!found.has(match.identifier)) {
         found.set(match.identifier, {
           identifier: match.identifier,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,7 @@ Options:
   --stage=<stage>            Deployment stage (required for update)
   --include-paths=<paths>    Filter commits by file paths (comma-separated globs)
   --include-subjects=<regex> Filter commits whose subject (first line) matches the regex
+  --issue-pattern=<regex>    Extract issue IDs from subjects via group 1 (e.g. for Conventional Commits: "\\[([A-Z]+-\\d+)\\]")
   --link <URL|Label=URL>       Add a link to the targeted release (repeatable)
   --document <Title=content> Attach a document to the release (repeatable, Title required)
   --document-file <[Title=]path> Attach a document from a file (title inferred from basename if omitted; "-" for stdin requires Title=-; repeatable)
@@ -116,6 +117,7 @@ const {
   baseRef,
   includePaths,
   includeSubjects,
+  issuePattern,
   links,
   documents: documentSpecs,
   releaseNotes: releaseNotesSpec,
@@ -350,6 +352,7 @@ async function syncCommand(): Promise<{
   const { issueReferences, revertedIssueReferences, prNumbers, debugSink } = scanCommits(commits, {
     includePaths: effectiveIncludePaths,
     includeSubjects,
+    issuePattern,
   });
 
   verbose(`Debug sink: ${JSON.stringify(debugSink, null, 2)}`);

--- a/src/scan.ts
+++ b/src/scan.ts
@@ -10,6 +10,7 @@ import { CommitContext, DebugSink, IssueReference, PullRequestSource } from "./t
 export type ScanOptions = {
   includePaths?: string[] | null;
   includeSubjects?: string | null;
+  issuePattern?: string | null;
 };
 
 /**
@@ -26,8 +27,9 @@ export function scanCommits(
   prNumbers: number[];
   debugSink: DebugSink;
 } {
-  const { includePaths = null, includeSubjects = null } = options;
+  const { includePaths = null, includeSubjects = null, issuePattern = null } = options;
   const subjectRegex = includeSubjects ? new RegExp(includeSubjects) : null;
+  const issuePatternRegex = issuePattern ? new RegExp(issuePattern, "i") : null;
   const lastAction = new Map<string, "added" | "reverted">();
   const addedRefs = new Map<string, IssueReference>();
   const revertedRefs = new Map<string, IssueReference>();
@@ -40,6 +42,7 @@ export function scanCommits(
     pullRequests: [],
     includePaths,
     includeSubjects,
+    issuePattern,
   };
 
   for (const commit of commits) {
@@ -68,7 +71,9 @@ export function scanCommits(
       verbose(`Detected reverted issue key ${identifier} from commit ${commit.sha}`);
     }
 
-    for (const { identifier, source } of extractLinearIssueIdentifiersForCommit(commit)) {
+    for (const { identifier, source } of extractLinearIssueIdentifiersForCommit(commit, {
+      issuePattern: issuePatternRegex,
+    })) {
       if (!debugSink.issues[identifier]) {
         debugSink.issues[identifier] = [];
       }

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,4 +109,5 @@ export type DebugSink = {
   pullRequests: PullRequestSource[]; // PR numbers found in commits
   includePaths: string[] | null; // Path filters applied during commit scanning
   includeSubjects: string | null; // Subject regex source applied during scanning
+  issuePattern: string | null; // Custom subject pattern for extracting issue identifiers
 };


### PR DESCRIPTION
## Summary

Closes #106.

The three built-in subject patterns in `COMMON_SUBJECT_PATTERNS` are all anchored to the start of the subject line, so teams that follow Conventional Commits — where the identifier appears after the type and scope — get no issue linked:

```
feat(routing)[ENG-123]: add stop reordering  ← not matched
fix[ENG-123]: handle empty payload           ← not matched
```

This adds a `--issue-pattern` flag that accepts a regex where group 1 captures the issue identifier. It's applied to the commit subject anywhere (not just the start), additive to the existing patterns:

```
linear-release sync --issue-pattern "\[([A-Z]+-[0-9]+)\]"
```

The pattern is validated as a legal regex at CLI entry. Invalid patterns produce a clear error:

```
Invalid --issue-pattern regex: Invalid regular expression: ...
```

## Changes

- `args.ts` — new `--issue-pattern` flag, validated and returned as `issuePattern: string | null`
- `extractors.ts` — `matchCustomSubjectPattern()` applies the user regex globally to the subject, validates group 1 captures through the existing `matchAllIdentifiers` path; wired into `extractLinearIssueIdentifiersForCommit` via an optional second argument
- `scan.ts` — `issuePattern` added to `ScanOptions`, compiled once before the commit loop, threaded into the extractor
- `index.ts` — destructured from parsed args, passed to `scanCommits`, added to help text