### PR TITLE
Bump package.json to 0.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-release",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "private": true,
   "description": "CLI tool to integrate CI/CD pipelines with Linear releases",
   "homepage": "https://github.com/linear/linear-release",


### PR DESCRIPTION
Release 0.17.0

First release published under the hardened pipeline from #130: immutable, with a `checksums.txt` manifest covering every executable. The action verifies these artifacts before execution starting with its v0.16.1 installer.

After this PR is merged, the `v0.17.0` tag will be created automatically, triggering the release workflow.