### PR TITLE
Pass the repository to gh release download in verify-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,7 +245,7 @@ jobs:
           TAG_NAME: ${{ needs.release.outputs.tag_name }}
         run: |
           mkdir release-assets
-          gh release download "$TAG_NAME" --dir release-assets
+          gh release download "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --dir release-assets
           cd release-assets
           sha256sum --check --strict checksums.txt
 


### PR DESCRIPTION
The `verify-release` job has no checkout, so `gh release download` had no git repo to infer the repository from and failed with `fatal: not a git repository` on v0.17.0's first run — before downloading anything. Pass `--repo "$GITHUB_REPOSITORY"` explicitly, like the metadata step already does.

The release itself was fine: the immutability and asset asserts passed in CI, and the checksum verification this step should have run passes against the published v0.17.0 assets locally.
