### PR TITLE
Release 0.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "linear-release",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "CLI tool to integrate CI/CD pipelines with Linear releases",
   "homepage": "https://github.com/linear/linear-release",


### PR DESCRIPTION
Fixes scan-base selection when several same-branch releases are open: a sync passing `--release-version` now resumes its own release instead of anchoring on whichever release ranks first. See #134.
